### PR TITLE
Point the CI badge at ci.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # naampy: Infer Sociodemographic Characteristics from Indian Names
 
-[![image](https://github.com/appeler/naampy/actions/workflows/test.yml/badge.svg)](https://github.com/appeler/naampy/actions/workflows/test.yml)
+[![CI](https://github.com/appeler/naampy/actions/workflows/ci.yml/badge.svg)](https://github.com/appeler/naampy/actions/workflows/ci.yml)
 [![Documentation](https://github.com/appeler/naampy/actions/workflows/docs.yml/badge.svg)](https://github.com/appeler/naampy/actions/workflows/docs.yml)
 [![image](https://img.shields.io/pypi/v/naampy.svg)](https://pypi.python.org/pypi/naampy)
 [![image](https://static.pepy.tech/badge/naampy)](https://pepy.tech/project/naampy)


### PR DESCRIPTION
The README's first badge referenced `test.yml`, a workflow that does not exist in this repo (the workflows are `ci.yml`, `docs.yml`, `release.yml`, plus the Dependabot and adjacent-repo helpers). It rendered as a 404 and blocked `preen release` on its critical broken-link check.

Both badge URLs now return HTTP 200:

```
.../actions/workflows/ci.yml/badge.svg   -> 200
.../actions/workflows/docs.yml/badge.svg -> 200
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)