### PR TITLE
Adopt the current build and Hub APIs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["uv_build>=0.11.32,<0.12"]
+requires = ["uv_build>=0.12.5,<0.13"]
 build-backend = "uv_build"
 
 [tool.uv.build-backend]
@@ -36,7 +36,7 @@ dependencies = [
   "pandas>=2.0.0",
   "requests>=2.25.0",
   "tqdm>=4.60.0",
-  "huggingface-hub>=0.23",
+  "huggingface-hub>=1.27.0",
   "pyarrow>=16",
 ]
 license-files = ["LICENSE"]

--- a/uv.lock
+++ b/uv.lock
@@ -719,7 +719,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "huggingface-hub", specifier = ">=0.23" },
+    { name = "huggingface-hub", specifier = ">=1.27.0" },
     { name = "numpy", specifier = ">=1.21.0" },
     { name = "pandas", specifier = ">=2.0.0" },
     { name = "pyarrow", specifier = ">=16" },


### PR DESCRIPTION
Use the fleet's current uv_build 0.12 series and Hugging Face Hub 1.27 public API baseline.

Validated with 45 tests, Ruff, formatting, Pyright, lock validation, uv build, and Twine metadata checks.