### PR TITLE
Establish leakage-safe Naampy model evaluation

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Managed by copier — records template version for `copier update`. Do not edit.
-_commit: v1
+_commit: v1.0.1
 _src_path: gh:gojiplus/py-canon
 author_email: gsood07@gmail.com
 author_name: Gaurav Sood

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add a reproducible evaluation report for the current character BiLSTM with
+  name-weighted and person-weighted probability metrics, name-cluster bootstrap
+  intervals, artifact hashes, and explicit developmental-evidence limitations.
+- Document the v2 and local v3 model-data dictionary, recodes, split contract,
+  hybrid lookup join contract, and unresolved provenance questions.
+
+### Changed
+
+- Use separate name-level training, validation, calibration, and final test
+  partitions for future training. Select the checkpoint on validation log loss,
+  fit logistic calibration on the calibration partition, and write a hashed
+  training manifest with final test results.
+- Type-check and lint the maintained model training and evaluation tools.
+
 ## [0.10.0] - 2026-08-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add a reproducible evaluation report for the current character BiLSTM with
+- Add a developmental evaluation report for the current character BiLSTM with
   name-weighted and person-weighted probability metrics, name-cluster bootstrap
-  intervals, artifact hashes, and explicit developmental-evidence limitations.
+  intervals, artifact hashes, fixed split provenance, and explicit limitations.
 - Document the v2 and local v3 model-data dictionary, recodes, split contract,
   hybrid lookup join contract, and unresolved provenance questions.
 
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fit logistic calibration on the calibration partition, and write a hashed
   training manifest with final test results.
 - Type-check and lint the maintained model training and evaluation tools.
+- Make v3 CSV.gz construction byte-deterministic and include its construction
+  program in source distributions. The unpublished inputs and transliteration
+  corpora still prevent an independent end-to-end reproduction claim.
 
 ## [0.10.0] - 2026-08-17
 

--- a/docs/examples/usage_examples.md
+++ b/docs/examples/usage_examples.md
@@ -37,6 +37,12 @@ Set `NAAMPY_MODEL_DIR` to a directory containing `gender_lstm.pt` when an offlin
 deployment supplies the checkpoint itself. Standard Hugging Face authentication,
 including `HF_TOKEN`, works automatically for Hub downloads.
 
+These runtime probabilities are raw and uncalibrated. The calibration parameters
+in the developmental evaluation report are used only by the offline evaluation
+tool; the current runtime does not load or apply that JSON. A separately trained
+checkpoint can be served as calibrated only when its accompanying training JSON
+is also loaded and its scale and intercept are applied to the raw model logits.
+
 ## State and year filters
 
 ```python

--- a/model_training/DATA.md
+++ b/model_training/DATA.md
@@ -17,13 +17,33 @@ cell. It is not necessarily a unique person across every underlying roll.
 | `naampy_v2.csv.gz` | 23,824,378 | 31 | 1887 to 2017 | 197,344 | 522,139,152 | 65 | `e47c917ba396aaa87f14db9e0fdc7dbbc83749987074802e93d2c228ec7ce9f8` |
 | `naampy_v2_1k.csv.gz` | 10,226,249 | 31 | 1887 to 2017 | 40,581 | 475,541,837 | 48 | `2f72d8555ee6da837f94adb93fad6661a80fa141abc1eda7fa4e17f565fe4417` |
 | `naampy_v2_native.csv.gz` | 3,719,116 | 16 | 1887 to 2017 | 110,267 | 410,965,158 | 0 | `899305b41330f944cc6e90a69e51147dd20bd680a23e9616f8a162841f45e6bd` |
-| local v3 construction | 6,670,064 | 31 | 1887 to 2017 | 125,636 | 466,713,646 | 65 | `a548226d9fe4c1dd7193d79487f51e55d77ad58e327b1b58e966b910e484ccf4` |
+| legacy local v3 checkpoint input | 6,670,064 | 31 | 1887 to 2017 | 125,636 | 466,713,646 | 65 | `a548226d9fe4c1dd7193d79487f51e55d77ad58e327b1b58e966b910e484ccf4` |
 
 The v2, v2_1k, and native files are published Dataverse transports. The local
 v3 construction retransliterates names from the native table with electoral
 roll word maps, then combines those states with v2 states that did not require
 retransliteration. The v3 file is currently gitignored and is not a published
-runtime table.
+runtime table. The hash in the table identifies the legacy gzip bytes used to
+train and audit the shipped checkpoint. Those bytes predate the canonical
+writer below and are not the expected hash of a newly constructed artifact.
+
+Build the full-coverage artifact from the repository root with both published
+transport inputs:
+
+```console
+python model_training/retransliterate_native.py \
+  --native /tmp/naampy_v2_native.csv.gz \
+  --v2 /tmp/naampy_v2.csv.gz \
+  --out model_training/data/naampy_v3.csv.gz
+```
+
+The construction program is included in source distributions. It uses a stable
+row order, fixed CSV formatting and line endings, and a gzip stream with no
+embedded filename and timestamp zero, so identical input tables, word maps,
+software, and code produce the same bytes and SHA-256 digest. The required word
+maps are not yet published at immutable revisions, so this is a deterministic
+construction procedure, not yet an independently reproducible data release or
+a source of a published canonical v3 hash.
 
 ## Data dictionary
 
@@ -72,8 +92,18 @@ used by training.
 
 The shipped checkpoint used a seeded 80 percent training and 20 percent
 development split over unique aggregated names. Exact names do not cross that
-boundary. The training loop reported the complete development result after
-every epoch, so the result is developmental rather than confirmatory evidence.
+boundary. Its membership is fixed by the original recipe's seed of zero; the
+evaluator does not expose that seed as an option. Bootstrap randomness has a
+separate option and cannot change split membership. The report records canonical
+SHA-256 hashes of the names in each partition. The training loop reported the
+complete development result after every epoch, so the result is developmental
+rather than confirmatory evidence.
+
+Evaluating a custom `--model` also requires `--training-manifest`. The evaluator
+verifies the manifest's data hash, checkpoint hash, split recipe, and all four
+name-membership hashes before using its calibration and test partitions. It
+refuses a custom checkpoint without that evidence instead of applying the
+shipped checkpoint's split to unrelated weights.
 
 The current-checkpoint audit reproduces that boundary, then partitions the
 development names into balanced calibration and test halves. The balancing
@@ -87,6 +117,17 @@ validation, 10 percent calibration, and 10 percent test contract in
 `model_training.evaluation`. Model selection may inspect only validation
 metrics. Calibration may use only the calibration partition. The final test
 partition may be scored only after the model and calibration method are frozen.
+
+Thresholded precision, recall, and F1 use fractional female shares to form
+expected individual-label confusion counts. Majority-name accuracy is named
+separately. Aggregate-composition mean squared error measures squared error
+against the observed name-level share; expected binary Brier score additionally
+includes the irreducible Bernoulli variance `female_share * (1 - female_share)`.
+
+The raw `.pt` checkpoint emits uncalibrated probabilities. Calibrated serving
+requires the accompanying JSON manifest and its fitted scale and intercept.
+Naampy's current runtime loads only the raw checkpoint and does not apply the
+offline calibration reported by the evaluation and training tools.
 
 ## Join contract for the hybrid product
 

--- a/model_training/DATA.md
+++ b/model_training/DATA.md
@@ -1,0 +1,124 @@
+# Naampy model data contract
+
+Naampy's neural model estimates the female share associated with a Latin-script
+first-name pattern in aggregated Indian electoral-roll records. It does not
+estimate a person's gender identity. The current checkpoint uses only female
+and male source counts because the available third-gender count is too small
+to train or evaluate a third class.
+
+## Source tables
+
+The figures below come from a full streaming profile of the locally retained
+Dataverse transport files. A represented record is a count in an aggregated
+cell. It is not necessarily a unique person across every underlying roll.
+
+| Table | State, year, name rows | States | Years | Distinct names | Represented records | Third-gender count | SHA-256 |
+| --- | ---: | ---: | --- | ---: | ---: | ---: | --- |
+| `naampy_v2.csv.gz` | 23,824,378 | 31 | 1887 to 2017 | 197,344 | 522,139,152 | 65 | `e47c917ba396aaa87f14db9e0fdc7dbbc83749987074802e93d2c228ec7ce9f8` |
+| `naampy_v2_1k.csv.gz` | 10,226,249 | 31 | 1887 to 2017 | 40,581 | 475,541,837 | 48 | `2f72d8555ee6da837f94adb93fad6661a80fa141abc1eda7fa4e17f565fe4417` |
+| `naampy_v2_native.csv.gz` | 3,719,116 | 16 | 1887 to 2017 | 110,267 | 410,965,158 | 0 | `899305b41330f944cc6e90a69e51147dd20bd680a23e9616f8a162841f45e6bd` |
+| local v3 construction | 6,670,064 | 31 | 1887 to 2017 | 125,636 | 466,713,646 | 65 | `a548226d9fe4c1dd7193d79487f51e55d77ad58e327b1b58e966b910e484ccf4` |
+
+The v2, v2_1k, and native files are published Dataverse transports. The local
+v3 construction retransliterates names from the native table with electoral
+roll word maps, then combines those states with v2 states that did not require
+retransliteration. The v3 file is currently gitignored and is not a published
+runtime table.
+
+## Data dictionary
+
+One source row represents an aggregated state, birth-year, and first-name
+cell. The key is unique in all four profiled tables.
+
+| Column | Type | Unit and universe | Missing values | Provenance and checks |
+| --- | --- | --- | --- | --- |
+| `state` | string | State or union-territory key for every aggregated cell | None observed | Electoral-roll processing pipeline |
+| `birth_year` | whole year | Birth year attached to every aggregated cell | None observed | v2 transports store whole years as floating-point text; the runtime cache validates and casts them to `int16` |
+| `first_name` | string | Processed first-name text for every cell | One blank row in local v3; none in published tables | Native input contains script-specific text; v2 and v2_1k contain Latin letters only |
+| `n_female` | nonnegative integer | Source records labeled female in the cell | None observed | Counts are nonnegative in every profiled table |
+| `n_male` | nonnegative integer | Source records labeled male in the cell | None observed | Counts are nonnegative in every profiled table |
+| `n_third_gender` | nonnegative integer | Source records labeled third gender in the cell | None observed | Only 65 represented records in v2 and local v3; zero in the native table |
+| `prop_female` | proportion | `n_female / (n_female + n_male + n_third_gender)` | None observed | Recomputed values matched the source within floating-point precision |
+
+No profiled table contains a zero-total cell, negative count, or duplicate key.
+The local v3 table contains 20,226 rows whose first-name value is not purely
+alphabetic, mostly because retransliteration produced spaces or multiple words.
+
+## Recode ledger
+
+The model-training loader aggregates every source row by `first_name`, sums the
+female and male counts, and computes the target as:
+
+```text
+female_proportion = female_count / (female_count + male_count)
+```
+
+It then applies these filters:
+
+| Source value | Model value | Reason and consequence |
+| --- | --- | --- |
+| Names shorter than 3 or longer than 19 characters | Excluded | Matches the current model's training scope |
+| Names containing nonalphabetic characters | Excluded | Removes spaces, punctuation, and malformed values |
+| Names containing the same character three times in sequence | Excluded | Removes a documented noisy-name pattern |
+| Characters outside Latin `a` to `z` | Dropped by the encoder | A name with no remaining characters is excluded |
+| Female and male counts | `person_count` | Used as the training and person-weighted evaluation weight |
+| Female share among female and male counts | Soft binary target | The model does not use the third-gender count |
+
+These steps produce 124,447 usable unique Latin-script names from the local v3
+construction. The evaluation code tests the recodes through the same loader
+used by training.
+
+## Split contract
+
+The shipped checkpoint used a seeded 80 percent training and 20 percent
+development split over unique aggregated names. Exact names do not cross that
+boundary. The training loop reported the complete development result after
+every epoch, so the result is developmental rather than confirmatory evidence.
+
+The current-checkpoint audit reproduces that boundary, then partitions the
+development names into balanced calibration and test halves. The balancing
+algorithm considers name count, represented records, female count, and male
+count. Calibration fits a positive-scale logistic transform. Test metrics are
+computed once after calibration and receive 95 percent name-cluster percentile
+bootstrap intervals.
+
+Future training must use the new stratified 70 percent training, 10 percent
+validation, 10 percent calibration, and 10 percent test contract in
+`model_training.evaluation`. Model selection may inspect only validation
+metrics. Calibration may use only the calibration partition. The final test
+partition may be scored only after the model and calibration method are frozen.
+
+## Join contract for the hybrid product
+
+The neural baseline does not join tables. The future hybrid evaluation will
+join a test-name table on the left to a lookup table aggregated to one row per
+normalized first name on the right.
+
+| Contract item | Requirement |
+| --- | --- |
+| Left table | Every evaluated name, preserved once and in its original order |
+| Right table | One row per normalized first name after the declared state and birth-year filters |
+| Key | Normalized first name |
+| Cardinality | Many evaluation rows to one lookup row |
+| Expected result rows | Exactly the number of left-table rows |
+| Miss behavior | Route to the binary neural model only when the script is supported; otherwise abstain |
+| Required diagnostics | Match rate overall and by state, year, script, support, and target class; unmatched examples; row-count identity |
+
+The lookup and neural paths do not share a label space. Lookup rows retain the
+published female, male, and third-gender composition. Neural fallback rows
+estimate only the binary female and male source target. The product must expose
+that difference and must not fill an unsupported third-gender probability with
+zero.
+
+## Open provenance questions
+
+- The published source documentation must establish whether represented
+  records can repeat the same person across roll editions.
+- Birth years before plausible modern electoral cohorts need a source-level
+  explanation or an explicit support rule.
+- The native string `[লে` and similar malformed-looking values need review
+  against the extraction source before any native-script model uses them.
+- The v3 transliteration word maps and construction environment need immutable
+  hashes before v3 can support a release claim.
+- The v3 training table needs publication in a versioned data repository or a
+  fully reproducible build from immutable inputs.

--- a/model_training/__init__.py
+++ b/model_training/__init__.py
@@ -1,0 +1,1 @@
+"""Reproducible training and evaluation tools for naampy models."""

--- a/model_training/evaluate_gender_model.py
+++ b/model_training/evaluate_gender_model.py
@@ -13,20 +13,25 @@ import argparse
 import hashlib
 import json
 import logging
+import math
 import tempfile
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 import torch
 
 from model_training.evaluation import (
+    NameDatasetSplit,
     balanced_calibration_test_split,
     bootstrap_metric_intervals,
     fit_logistic_calibration,
     legacy_development_split,
+    name_membership_sha256,
     partition_summary,
     report_metrics,
+    split_summary,
+    stratified_name_split,
 )
 from model_training.train_gender_lstm import load_names
 from naampy._resources import HF_REPO, HF_REVISION, resolve_model
@@ -41,6 +46,7 @@ from naampy.nnets import (
 )
 
 LOGGER = logging.getLogger(__name__)
+SHIPPED_CHECKPOINT_SPLIT_SEED = 0
 
 
 def file_sha256(path: Path) -> str:
@@ -74,7 +80,7 @@ def metric_report_with_intervals(
     person_counts: np.ndarray,
     *,
     bootstrap_iterations: int,
-    seed: int,
+    bootstrap_seed: int,
 ) -> dict[str, Any]:
     """Return point estimates and name-cluster bootstrap intervals."""
     return {
@@ -85,19 +91,20 @@ def metric_report_with_intervals(
             "method": "name-cluster percentile bootstrap",
             "confidence_level": 0.95,
             "iterations": bootstrap_iterations,
+            "seed": bootstrap_seed,
             "name_weighted": bootstrap_metric_intervals(
                 probabilities,
                 female_proportions,
                 np.ones_like(person_counts, dtype=np.float64),
                 iterations=bootstrap_iterations,
-                seed=seed,
+                seed=bootstrap_seed,
             ),
             "person_weighted": bootstrap_metric_intervals(
                 probabilities,
                 female_proportions,
                 person_counts,
                 iterations=bootstrap_iterations,
-                seed=seed,
+                seed=bootstrap_seed,
             ),
         },
     }
@@ -121,36 +128,195 @@ def write_json_atomic(report: dict[str, Any], output_path: Path) -> None:
     output_path.chmod(0o644)
 
 
+def load_verified_training_split(
+    manifest_path: Path,
+    data_path: Path,
+    model_path: Path,
+    names: list[str],
+    female_proportions: np.ndarray,
+    person_counts: np.ndarray,
+) -> tuple[NameDatasetSplit, dict[str, Any]]:
+    """Load and verify the split provenance for a custom checkpoint."""
+    manifest = cast(
+        "dict[str, Any]", json.loads(manifest_path.read_text(encoding="utf-8"))
+    )
+    if manifest.get("schema_version") != 2:
+        raise ValueError("training manifest must use schema version 2")
+    if manifest["data"]["sha256"] != file_sha256(data_path):
+        raise ValueError("training manifest data hash does not match --data")
+    if manifest["model"]["sha256"] != file_sha256(model_path):
+        raise ValueError("training manifest model hash does not match --model")
+    split_manifest = manifest["split"]
+    if split_manifest["method"] != "stratified disjoint unique-name split":
+        raise ValueError("unsupported training manifest split method")
+    fractions = split_manifest["fractions"]
+    declared_fractions = {
+        partition: float(fractions[partition])
+        for partition in ("training", "validation", "calibration", "test")
+    }
+    if not math.isclose(
+        sum(declared_fractions.values()), 1.0, rel_tol=0.0, abs_tol=1e-12
+    ):
+        raise ValueError("training manifest split fractions must sum to 1")
+    strata = split_manifest["strata"]
+    split = stratified_name_split(
+        female_proportions,
+        person_counts,
+        seed=int(split_manifest["seed"]),
+        training_fraction=declared_fractions["training"],
+        validation_fraction=declared_fractions["validation"],
+        calibration_fraction=declared_fractions["calibration"],
+        count_strata=int(strata["person_count_rank_bins"]),
+        proportion_strata=int(strata["female_proportion_bins"]),
+    )
+    expected_hashes = split_manifest["membership_sha256"]
+    actual_hashes = {
+        "training": name_membership_sha256(names, split.training),
+        "validation": name_membership_sha256(names, split.validation),
+        "calibration": name_membership_sha256(names, split.calibration),
+        "test": name_membership_sha256(names, split.test),
+    }
+    if expected_hashes != actual_hashes:
+        raise ValueError("training manifest membership hashes do not match --data")
+    return split, manifest
+
+
 def main() -> None:
     """Evaluate the pinned checkpoint and write its evidence report."""
     parser = argparse.ArgumentParser()
     parser.add_argument("--data", required=True, type=Path)
     parser.add_argument("--model", type=Path)
+    parser.add_argument("--training-manifest", type=Path)
     parser.add_argument("--output", required=True, type=Path)
     parser.add_argument("--bootstrap-iterations", type=int, default=1_000)
-    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--bootstrap-seed", type=int, default=0)
     arguments = parser.parse_args()
 
-    names, encoded_names, female_proportions, person_counts = load_names(arguments.data)
+    max_source_rows: int | None = None
+    if arguments.model is not None:
+        if arguments.training_manifest is None:
+            parser.error("--model requires --training-manifest")
+        try:
+            manifest_preview = cast(
+                "dict[str, Any]",
+                json.loads(arguments.training_manifest.read_text(encoding="utf-8")),
+            )
+            recorded_row_cap = manifest_preview["training"]["hyperparameters"][
+                "max_source_rows"
+            ]
+            if recorded_row_cap is not None:
+                if (
+                    isinstance(recorded_row_cap, bool)
+                    or not isinstance(recorded_row_cap, int)
+                    or recorded_row_cap < 1
+                ):
+                    raise ValueError(
+                        "training manifest max_source_rows must be null or a positive integer"
+                    )
+                max_source_rows = recorded_row_cap
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
+            parser.error(str(error))
+
+    names, encoded_names, female_proportions, person_counts = load_names(
+        arguments.data, max_source_rows
+    )
     proportions = np.asarray(female_proportions)
     counts = np.asarray(person_counts)
-    training_indices, held_out_indices = legacy_development_split(
-        len(names), seed=arguments.seed
-    )
-    calibration_indices, test_indices = balanced_calibration_test_split(
-        held_out_indices, proportions, counts
-    )
-    model_path = (
-        arguments.model
-        if arguments.model is not None
-        else Path(resolve_model("gender_lstm.pt"))
-    )
+    if arguments.model is None:
+        if arguments.training_manifest is not None:
+            parser.error("--training-manifest requires --model")
+        model_path = Path(resolve_model("gender_lstm.pt"))
+        training_indices, held_out_indices = legacy_development_split(
+            len(names), seed=SHIPPED_CHECKPOINT_SPLIT_SEED
+        )
+        calibration_indices, test_indices = balanced_calibration_test_split(
+            held_out_indices, proportions, counts
+        )
+        model_provenance = {
+            "source": "hugging_face_hub",
+            "repository": HF_REPO,
+            "revision": HF_REVISION,
+        }
+        data_artifact_encoding = (
+            "legacy pandas gzip output predating the canonical deterministic writer"
+        )
+        split_method = (
+            "original seeded 80/20 unique-name split; held-out names balanced "
+            "into calibration and test halves by support and label composition"
+        )
+        split_provenance: dict[str, Any] = {
+            "membership_provenance": {
+                "recipe": "Python random.Random shuffle followed by an 80/20 cutoff",
+                "fixed_seed": SHIPPED_CHECKPOINT_SPLIT_SEED,
+                "source": "shipped checkpoint training recipe",
+            },
+            "membership_sha256": {
+                "original_training": name_membership_sha256(names, training_indices),
+                "original_held_out": name_membership_sha256(names, held_out_indices),
+                "calibration": name_membership_sha256(names, calibration_indices),
+                "test": name_membership_sha256(names, test_indices),
+            },
+            "summary": {
+                "original_training": partition_summary(
+                    training_indices, proportions, counts
+                ),
+                "calibration": partition_summary(
+                    calibration_indices, proportions, counts
+                ),
+                "test": partition_summary(test_indices, proportions, counts),
+            },
+        }
+        original_held_out_probabilities_required = True
+    else:
+        if arguments.training_manifest is None:
+            parser.error("--model requires --training-manifest")
+        training_manifest_path = arguments.training_manifest
+        model_path = arguments.model
+        try:
+            custom_split, training_manifest = load_verified_training_split(
+                training_manifest_path,
+                arguments.data,
+                model_path,
+                names,
+                proportions,
+                counts,
+            )
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
+            parser.error(str(error))
+        training_indices = custom_split.training
+        held_out_indices = np.asarray([], dtype=np.int64)
+        calibration_indices = custom_split.calibration
+        test_indices = custom_split.test
+        model_provenance = {
+            "source": "user_provided_local_path",
+            "path": str(model_path),
+            "training_manifest": {
+                "filename": training_manifest_path.name,
+                "sha256": file_sha256(training_manifest_path),
+            },
+        }
+        data_artifact_encoding = training_manifest["data"].get(
+            "artifact_encoding", "unspecified"
+        )
+        split_method = training_manifest["split"]["method"]
+        split_provenance = {
+            "seed": training_manifest["split"]["seed"],
+            "fractions": training_manifest["split"]["fractions"],
+            "strata": training_manifest["split"]["strata"],
+            "membership_sha256": training_manifest["split"]["membership_sha256"],
+            "summary": split_summary(custom_split, proportions, counts),
+        }
+        original_held_out_probabilities_required = False
     model = CharBiLSTM(VOCAB_SIZE, 1, LSTM_EMB, LSTM_HIDDEN, LSTM_LAYERS, LSTM_DROPOUT)
     state = torch.load(model_path, map_location="cpu", weights_only=True)
     model.load_state_dict(state)
 
-    held_out_probabilities = predict_probabilities(
-        model, [encoded_names[index] for index in held_out_indices]
+    held_out_probabilities = (
+        predict_probabilities(
+            model, [encoded_names[index] for index in held_out_indices]
+        )
+        if original_held_out_probabilities_required
+        else None
     )
     calibration_probabilities = predict_probabilities(
         model, [encoded_names[index] for index in calibration_indices]
@@ -164,35 +330,53 @@ def main() -> None:
         counts[calibration_indices],
     )
     calibrated_test_probabilities = calibration.apply(test_probabilities)
+    limitations = [
+        (
+            "The binary model excludes the extremely sparse third-gender label "
+            "and does not estimate gender identity."
+        ),
+        (
+            "The calibration in this report is an offline evaluation transform; "
+            "the current Naampy runtime serves the raw checkpoint probabilities."
+        ),
+    ]
+    if original_held_out_probabilities_required:
+        limitations.insert(
+            0,
+            (
+                "The checkpoint training loop monitored the complete original "
+                "held-out partition after every epoch; this is not confirmatory evidence."
+            ),
+        )
+    else:
+        limitations.insert(
+            0,
+            (
+                "The training manifest verifies data, checkpoint, and split membership, "
+                "but this evaluator does not independently verify the training process."
+            ),
+        )
 
     report = {
-        "schema_version": 1,
+        "schema_version": 2,
         "evidence_role": "developmental",
         "target": "female share among female and male electoral-roll labels",
         "reference_population": (
             "aggregated Indian electoral-roll registration records represented "
             "in the local naampy v3 construction"
         ),
-        "limitations": [
-            (
-                "The checkpoint training loop monitored the complete original "
-                "held-out partition after every epoch; this is not confirmatory evidence."
-            ),
-            (
-                "The binary model excludes the extremely sparse third-gender label "
-                "and does not estimate gender identity."
-            ),
-        ],
+        "limitations": limitations,
         "data": {
             "filename": arguments.data.name,
             "sha256": file_sha256(arguments.data),
             "usable_unique_names": len(names),
+            "artifact_encoding": data_artifact_encoding,
+            "source_row_limit": max_source_rows,
         },
         "model": {
             "filename": model_path.name,
             "sha256": file_sha256(model_path),
-            "hugging_face_repository": HF_REPO,
-            "hugging_face_revision": HF_REVISION,
+            "provenance": model_provenance,
             "architecture": {
                 "type": "character_bidirectional_lstm",
                 "vocabulary_size": VOCAB_SIZE,
@@ -202,58 +386,38 @@ def main() -> None:
                 "dropout": LSTM_DROPOUT,
             },
         },
-        "split": {
-            "method": (
-                "original seeded 80/20 unique-name split; held-out names balanced "
-                "into calibration and test halves by support and label composition"
-            ),
-            "seed": arguments.seed,
-            "summary": {
-                "original_training": partition_summary(
-                    training_indices,
-                    proportions,
-                    counts,
-                ),
-                "calibration": partition_summary(
-                    calibration_indices,
-                    proportions,
-                    counts,
-                ),
-                "test": partition_summary(
-                    test_indices,
-                    proportions,
-                    counts,
-                ),
-            },
-        },
+        "split": {"method": split_method, **split_provenance},
         "calibration": {
             "method": "positive-scale logistic calibration",
             "scale": calibration.scale,
             "intercept": calibration.intercept,
             "fit_partition": "calibration",
+            "required_for_calibrated_serving": True,
+            "current_runtime_status": "not_applied",
         },
         "metrics": {
-            "original_held_out_raw": report_metrics(
-                held_out_probabilities,
-                proportions[held_out_indices],
-                counts[held_out_indices],
-            ),
             "balanced_test_raw": metric_report_with_intervals(
                 test_probabilities,
                 proportions[test_indices],
                 counts[test_indices],
                 bootstrap_iterations=arguments.bootstrap_iterations,
-                seed=arguments.seed,
+                bootstrap_seed=arguments.bootstrap_seed,
             ),
             "balanced_test_calibrated": metric_report_with_intervals(
                 calibrated_test_probabilities,
                 proportions[test_indices],
                 counts[test_indices],
                 bootstrap_iterations=arguments.bootstrap_iterations,
-                seed=arguments.seed,
+                bootstrap_seed=arguments.bootstrap_seed,
             ),
         },
     }
+    if held_out_probabilities is not None:
+        report["metrics"]["original_held_out_raw"] = report_metrics(
+            held_out_probabilities,
+            proportions[held_out_indices],
+            counts[held_out_indices],
+        )
     write_json_atomic(report, arguments.output)
     LOGGER.info("Wrote evaluation report to %s", arguments.output)
 

--- a/model_training/evaluate_gender_model.py
+++ b/model_training/evaluate_gender_model.py
@@ -165,6 +165,12 @@ def load_verified_training_split(
     )
     if manifest.get("schema_version") != 2:
         raise ValueError("training manifest must use schema version 2")
+    for metadata_field in ("target", "reference_population"):
+        metadata_value = manifest.get(metadata_field)
+        if not isinstance(metadata_value, str) or not metadata_value.strip():
+            raise ValueError(
+                f"training manifest {metadata_field} must be a nonempty string"
+            )
     if manifest["data"]["sha256"] != file_sha256(data_path):
         raise ValueError("training manifest data hash does not match --data")
     if manifest["model"]["sha256"] != file_sha256(model_path):
@@ -283,6 +289,11 @@ def main() -> None:
         data_artifact_encoding = (
             "legacy pandas gzip output predating the canonical deterministic writer"
         )
+        target_description = "female share among female and male electoral-roll labels"
+        reference_population = (
+            "aggregated Indian electoral-roll registration records represented "
+            "in the local naampy v3 construction"
+        )
         split_method = (
             "original seeded 80/20 unique-name split; held-out names balanced "
             "into calibration and test halves by support and label composition"
@@ -341,6 +352,8 @@ def main() -> None:
         data_artifact_encoding = training_manifest["data"].get(
             "artifact_encoding", "unspecified"
         )
+        target_description = training_manifest["target"]
+        reference_population = training_manifest["reference_population"]
         split_method = training_manifest["split"]["method"]
         split_provenance = {
             "seed": training_manifest["split"]["seed"],
@@ -403,11 +416,8 @@ def main() -> None:
     report = {
         "schema_version": 2,
         "evidence_role": "developmental",
-        "target": "female share among female and male electoral-roll labels",
-        "reference_population": (
-            "aggregated Indian electoral-roll registration records represented "
-            "in the local naampy v3 construction"
-        ),
+        "target": target_description,
+        "reference_population": reference_population,
         "limitations": limitations,
         "data": {
             "filename": arguments.data.name,

--- a/model_training/evaluate_gender_model.py
+++ b/model_training/evaluate_gender_model.py
@@ -1,0 +1,263 @@
+"""Evaluate the shipped gender-pattern checkpoint on its held-out names.
+
+Run from the repository root:
+
+    python -m model_training.evaluate_gender_model \
+        --data model_training/data/naampy_v3.csv.gz \
+        --output model_training/reports/gender_lstm_f7f2b7ac.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+
+from model_training.evaluation import (
+    balanced_calibration_test_split,
+    bootstrap_metric_intervals,
+    fit_logistic_calibration,
+    legacy_development_split,
+    partition_summary,
+    report_metrics,
+)
+from model_training.train_gender_lstm import load_names
+from naampy._resources import HF_REPO, HF_REVISION, resolve_model
+from naampy.nnets import (
+    LSTM_DROPOUT,
+    LSTM_EMB,
+    LSTM_HIDDEN,
+    LSTM_LAYERS,
+    VOCAB_SIZE,
+    CharBiLSTM,
+    pad_encoded,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+
+def file_sha256(path: Path) -> str:
+    """Return the SHA-256 digest of a file."""
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        while chunk := source.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+@torch.no_grad()
+def predict_probabilities(
+    model: CharBiLSTM, encoded_names: list[list[int]]
+) -> np.ndarray:
+    """Return female probabilities for encoded names."""
+    model.eval()
+    probabilities: list[float] = []
+    for start in range(0, len(encoded_names), 512):
+        inputs, lengths = pad_encoded(encoded_names[start : start + 512])
+        batch_probabilities = (
+            torch.sigmoid(model(inputs, lengths)).squeeze(1).cpu().numpy()
+        )
+        probabilities.extend(batch_probabilities.tolist())
+    return np.asarray(probabilities)
+
+
+def metric_report_with_intervals(
+    probabilities: np.ndarray,
+    female_proportions: np.ndarray,
+    person_counts: np.ndarray,
+    *,
+    bootstrap_iterations: int,
+    seed: int,
+) -> dict[str, Any]:
+    """Return point estimates and name-cluster bootstrap intervals."""
+    return {
+        "point_estimates": report_metrics(
+            probabilities, female_proportions, person_counts
+        ),
+        "intervals": {
+            "method": "name-cluster percentile bootstrap",
+            "confidence_level": 0.95,
+            "iterations": bootstrap_iterations,
+            "name_weighted": bootstrap_metric_intervals(
+                probabilities,
+                female_proportions,
+                np.ones_like(person_counts, dtype=np.float64),
+                iterations=bootstrap_iterations,
+                seed=seed,
+            ),
+            "person_weighted": bootstrap_metric_intervals(
+                probabilities,
+                female_proportions,
+                person_counts,
+                iterations=bootstrap_iterations,
+                seed=seed,
+            ),
+        },
+    }
+
+
+def write_json_atomic(report: dict[str, Any], output_path: Path) -> None:
+    """Write a JSON report without exposing a partial file."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        dir=output_path.parent,
+        prefix=f".{output_path.name}.",
+        suffix=".tmp",
+        delete=False,
+    ) as temporary_file:
+        json.dump(report, temporary_file, indent=2, sort_keys=True)
+        temporary_file.write("\n")
+        temporary_path = Path(temporary_file.name)
+    temporary_path.replace(output_path)
+    output_path.chmod(0o644)
+
+
+def main() -> None:
+    """Evaluate the pinned checkpoint and write its evidence report."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--data", required=True, type=Path)
+    parser.add_argument("--model", type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--bootstrap-iterations", type=int, default=1_000)
+    parser.add_argument("--seed", type=int, default=0)
+    arguments = parser.parse_args()
+
+    names, encoded_names, female_proportions, person_counts = load_names(arguments.data)
+    proportions = np.asarray(female_proportions)
+    counts = np.asarray(person_counts)
+    training_indices, held_out_indices = legacy_development_split(
+        len(names), seed=arguments.seed
+    )
+    calibration_indices, test_indices = balanced_calibration_test_split(
+        held_out_indices, proportions, counts
+    )
+    model_path = (
+        arguments.model
+        if arguments.model is not None
+        else Path(resolve_model("gender_lstm.pt"))
+    )
+    model = CharBiLSTM(VOCAB_SIZE, 1, LSTM_EMB, LSTM_HIDDEN, LSTM_LAYERS, LSTM_DROPOUT)
+    state = torch.load(model_path, map_location="cpu", weights_only=True)
+    model.load_state_dict(state)
+
+    held_out_probabilities = predict_probabilities(
+        model, [encoded_names[index] for index in held_out_indices]
+    )
+    calibration_probabilities = predict_probabilities(
+        model, [encoded_names[index] for index in calibration_indices]
+    )
+    test_probabilities = predict_probabilities(
+        model, [encoded_names[index] for index in test_indices]
+    )
+    calibration = fit_logistic_calibration(
+        calibration_probabilities,
+        proportions[calibration_indices],
+        counts[calibration_indices],
+    )
+    calibrated_test_probabilities = calibration.apply(test_probabilities)
+
+    report = {
+        "schema_version": 1,
+        "evidence_role": "developmental",
+        "target": "female share among female and male electoral-roll labels",
+        "reference_population": (
+            "aggregated Indian electoral-roll registration records represented "
+            "in the local naampy v3 construction"
+        ),
+        "limitations": [
+            (
+                "The checkpoint training loop monitored the complete original "
+                "held-out partition after every epoch; this is not confirmatory evidence."
+            ),
+            (
+                "The binary model excludes the extremely sparse third-gender label "
+                "and does not estimate gender identity."
+            ),
+        ],
+        "data": {
+            "filename": arguments.data.name,
+            "sha256": file_sha256(arguments.data),
+            "usable_unique_names": len(names),
+        },
+        "model": {
+            "filename": model_path.name,
+            "sha256": file_sha256(model_path),
+            "hugging_face_repository": HF_REPO,
+            "hugging_face_revision": HF_REVISION,
+            "architecture": {
+                "type": "character_bidirectional_lstm",
+                "vocabulary_size": VOCAB_SIZE,
+                "embedding_dimension": LSTM_EMB,
+                "hidden_dimension": LSTM_HIDDEN,
+                "layers": LSTM_LAYERS,
+                "dropout": LSTM_DROPOUT,
+            },
+        },
+        "split": {
+            "method": (
+                "original seeded 80/20 unique-name split; held-out names balanced "
+                "into calibration and test halves by support and label composition"
+            ),
+            "seed": arguments.seed,
+            "summary": {
+                "original_training": partition_summary(
+                    training_indices,
+                    proportions,
+                    counts,
+                ),
+                "calibration": partition_summary(
+                    calibration_indices,
+                    proportions,
+                    counts,
+                ),
+                "test": partition_summary(
+                    test_indices,
+                    proportions,
+                    counts,
+                ),
+            },
+        },
+        "calibration": {
+            "method": "positive-scale logistic calibration",
+            "scale": calibration.scale,
+            "intercept": calibration.intercept,
+            "fit_partition": "calibration",
+        },
+        "metrics": {
+            "original_held_out_raw": report_metrics(
+                held_out_probabilities,
+                proportions[held_out_indices],
+                counts[held_out_indices],
+            ),
+            "balanced_test_raw": metric_report_with_intervals(
+                test_probabilities,
+                proportions[test_indices],
+                counts[test_indices],
+                bootstrap_iterations=arguments.bootstrap_iterations,
+                seed=arguments.seed,
+            ),
+            "balanced_test_calibrated": metric_report_with_intervals(
+                calibrated_test_probabilities,
+                proportions[test_indices],
+                counts[test_indices],
+                bootstrap_iterations=arguments.bootstrap_iterations,
+                seed=arguments.seed,
+            ),
+        },
+    }
+    write_json_atomic(report, arguments.output)
+    LOGGER.info("Wrote evaluation report to %s", arguments.output)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    main()

--- a/model_training/evaluate_gender_model.py
+++ b/model_training/evaluate_gender_model.py
@@ -14,6 +14,7 @@ import hashlib
 import json
 import logging
 import math
+import os
 import tempfile
 from pathlib import Path
 from typing import Any, cast
@@ -34,7 +35,7 @@ from model_training.evaluation import (
     stratified_name_split,
 )
 from model_training.train_gender_lstm import load_names
-from naampy._resources import HF_REPO, HF_REVISION, resolve_model
+from naampy._resources import HF_REPO, HF_REVISION, MODEL_DIR_ENV, resolve_model
 from naampy.nnets import (
     LSTM_DROPOUT,
     LSTM_EMB,
@@ -47,6 +48,12 @@ from naampy.nnets import (
 
 LOGGER = logging.getLogger(__name__)
 SHIPPED_CHECKPOINT_SPLIT_SEED = 0
+SHIPPED_CHECKPOINT_DATA_SHA256 = (
+    "a548226d9fe4c1dd7193d79487f51e55d77ad58e327b1b58e966b910e484ccf4"
+)
+SHIPPED_GENDER_MODEL_SHA256 = (
+    "98fdcfe9016b48e3a2639c6f2c55eb9d2a56946a51dea6ac0a0c64fafc33b9f7"
+)
 
 
 def file_sha256(path: Path) -> str:
@@ -56,6 +63,22 @@ def file_sha256(path: Path) -> str:
         while chunk := source.read(1024 * 1024):
             digest.update(chunk)
     return digest.hexdigest()
+
+
+def verify_shipped_evaluation_artifacts(data_path: Path, model_path: Path) -> None:
+    """Verify the exact data and checkpoint used by the shipped-model audit."""
+    if file_sha256(data_path) != SHIPPED_CHECKPOINT_DATA_SHA256:
+        raise ValueError(
+            "--data does not match the immutable input used to train the shipped "
+            "checkpoint; evaluate a custom data/model pair with --model and "
+            "--training-manifest"
+        )
+    if file_sha256(model_path) != SHIPPED_GENDER_MODEL_SHA256:
+        raise ValueError(
+            "the resolved gender_lstm.pt does not match the checkpoint pinned by "
+            "Naampy; evaluate a custom checkpoint with --model and "
+            "--training-manifest"
+        )
 
 
 @torch.no_grad()
@@ -217,23 +240,43 @@ def main() -> None:
         except (KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
             parser.error(str(error))
 
+    shipped_model_path: Path | None = None
+    if arguments.model is None:
+        if arguments.training_manifest is not None:
+            parser.error("--training-manifest requires --model")
+        shipped_model_path = Path(resolve_model("gender_lstm.pt"))
+        try:
+            verify_shipped_evaluation_artifacts(arguments.data, shipped_model_path)
+        except ValueError as error:
+            parser.error(str(error))
+
     names, encoded_names, female_proportions, person_counts = load_names(
         arguments.data, max_source_rows
     )
     proportions = np.asarray(female_proportions)
     counts = np.asarray(person_counts)
     if arguments.model is None:
-        if arguments.training_manifest is not None:
-            parser.error("--training-manifest requires --model")
-        model_path = Path(resolve_model("gender_lstm.pt"))
+        if shipped_model_path is None:
+            raise RuntimeError("shipped checkpoint path was not resolved")
+        model_path = shipped_model_path
         training_indices, held_out_indices = legacy_development_split(
             len(names), seed=SHIPPED_CHECKPOINT_SPLIT_SEED
         )
         calibration_indices, test_indices = balanced_calibration_test_split(
             held_out_indices, proportions, counts
         )
+        local_model_directory = os.environ.get(MODEL_DIR_ENV)
+        expected_local_path = (
+            Path(local_model_directory) / model_path.name
+            if local_model_directory
+            else None
+        )
         model_provenance = {
-            "source": "hugging_face_hub",
+            "source": (
+                "verified_local_mirror"
+                if expected_local_path == model_path
+                else "hugging_face_hub"
+            ),
             "repository": HF_REPO,
             "revision": HF_REVISION,
         }

--- a/model_training/evaluation.py
+++ b/model_training/evaluation.py
@@ -124,6 +124,7 @@ def balanced_calibration_test_split(
             (counts[held_out] * (1 - proportions[held_out])).sum() / 2,
         ]
     )
+    balance_scale = np.where(target > 0, target, 1.0)
     totals = [np.zeros(4), np.zeros(4)]
     partitions: tuple[list[int], list[int]] = ([], [])
     ordered = sorted(held_out.tolist(), key=lambda index: (-counts[index], index))
@@ -140,14 +141,15 @@ def balanced_calibration_test_split(
         for side in (0, 1):
             candidate = [totals[0].copy(), totals[1].copy()]
             candidate[side] += contribution
-            costs.append(np.square((candidate[0] - candidate[1]) / target).sum())
+            costs.append(np.square((candidate[0] - candidate[1]) / balance_scale).sum())
         selected_side = 0 if costs[0] <= costs[1] else 1
         totals[selected_side] += contribution
         partitions[selected_side].append(index)
-    return (
-        np.asarray(partitions[0], dtype=np.int64),
-        np.asarray(partitions[1], dtype=np.int64),
-    )
+    calibration = np.asarray(partitions[0], dtype=np.int64)
+    test = np.asarray(partitions[1], dtype=np.int64)
+    if len(calibration) == 0 or len(test) == 0:
+        raise RuntimeError("balanced split unexpectedly produced an empty partition")
+    return calibration, test
 
 
 def _partition_balance_cost(

--- a/model_training/evaluation.py
+++ b/model_training/evaluation.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 import random
 from dataclasses import asdict, dataclass
 from typing import Any
@@ -22,9 +24,12 @@ class NameDatasetSplit:
 
     def validate(self, number_of_names: int) -> None:
         """Validate that the partitions are disjoint and exhaustive."""
-        combined = np.concatenate(
-            (self.training, self.validation, self.calibration, self.test)
-        )
+        partitions = (self.training, self.validation, self.calibration, self.test)
+        if any(len(partition) == 0 for partition in partitions):
+            raise ValueError(
+                "Training, validation, calibration, and test must be nonempty"
+            )
+        combined = np.concatenate(partitions)
         if len(combined) != number_of_names:
             raise ValueError("Split does not contain every name exactly once")
         if len(np.unique(combined)) != number_of_names:
@@ -51,17 +56,19 @@ class LogisticCalibration:
 
 @dataclass(frozen=True)
 class ProbabilityMetrics:
-    """Binary probability and threshold metrics."""
+    """Aggregate-composition and expected individual-label metrics."""
 
-    majority_label_accuracy: float
+    majority_name_label_accuracy: float
     expected_person_accuracy: float
-    female_precision: float
-    female_recall: float
-    male_recall: float
-    female_f1: float
-    brier_score: float
-    root_brier_score: float
-    soft_log_loss: float
+    expected_female_precision: float
+    expected_female_recall: float
+    expected_male_recall: float
+    expected_female_f1: float
+    aggregate_composition_mean_squared_error: float
+    aggregate_composition_root_mean_squared_error: float
+    expected_binary_brier_score: float
+    expected_binary_root_brier_score: float
+    expected_binary_log_loss: float
     calibration_error_10_bins: float
 
     def as_dict(self) -> dict[str, float]:
@@ -143,6 +150,109 @@ def balanced_calibration_test_split(
     )
 
 
+def _partition_balance_cost(
+    partition_contributions: np.ndarray, allocation_fractions: np.ndarray
+) -> float:
+    """Return the largest support-share or composition imbalance."""
+    overall_contributions = partition_contributions.sum(axis=0)
+    support_shares = partition_contributions[:, 0] / overall_contributions[0]
+    female_compositions = partition_contributions[:, 1] / partition_contributions[:, 0]
+    overall_female_composition = overall_contributions[1] / overall_contributions[0]
+    return float(
+        max(
+            np.abs(support_shares - allocation_fractions).max(),
+            np.abs(female_compositions - overall_female_composition).max(),
+        )
+    )
+
+
+def _refine_partition_balance(
+    partitions: list[list[int]],
+    contributions: np.ndarray,
+    allocation_fractions: np.ndarray,
+    random_generator: np.random.Generator,
+) -> None:
+    """Improve final balance through exact-size-preserving pair swaps."""
+    partition_contributions = np.asarray(
+        [contributions[partition].sum(axis=0) for partition in partitions]
+    )
+    current_cost = _partition_balance_cost(
+        partition_contributions, allocation_fractions
+    )
+    candidate_limit = 64
+    for _ in range(25):
+        candidate_positions: list[np.ndarray] = []
+        for partition in partitions:
+            if len(partition) <= candidate_limit:
+                candidate_positions.append(np.arange(len(partition)))
+                continue
+            extreme_positions = {
+                int(np.argmin(contributions[partition, feature_index]))
+                for feature_index in range(contributions.shape[1])
+            } | {
+                int(np.argmax(contributions[partition, feature_index]))
+                for feature_index in range(contributions.shape[1])
+            }
+            remaining_positions = np.setdiff1d(
+                np.arange(len(partition)),
+                np.fromiter(extreme_positions, dtype=np.int64),
+            )
+            sampled_positions = random_generator.choice(
+                remaining_positions,
+                size=candidate_limit - len(extreme_positions),
+                replace=False,
+            )
+            candidate_positions.append(
+                np.concatenate(
+                    (np.fromiter(extreme_positions, dtype=np.int64), sampled_positions)
+                )
+            )
+
+        best_swap: tuple[int, int, int, int, np.ndarray] | None = None
+        best_cost = current_cost
+        for first_partition in range(4):
+            for second_partition in range(first_partition + 1, 4):
+                for first_position in candidate_positions[first_partition]:
+                    first_index = partitions[first_partition][first_position]
+                    for second_position in candidate_positions[second_partition]:
+                        second_index = partitions[second_partition][second_position]
+                        candidate_contributions = partition_contributions.copy()
+                        difference = (
+                            contributions[second_index] - contributions[first_index]
+                        )
+                        candidate_contributions[first_partition] += difference
+                        candidate_contributions[second_partition] -= difference
+                        candidate_cost = _partition_balance_cost(
+                            candidate_contributions, allocation_fractions
+                        )
+                        if candidate_cost < best_cost - 1e-12:
+                            best_cost = candidate_cost
+                            best_swap = (
+                                first_partition,
+                                second_partition,
+                                int(first_position),
+                                int(second_position),
+                                candidate_contributions,
+                            )
+        if best_swap is None:
+            break
+        (
+            first_partition,
+            second_partition,
+            first_position,
+            second_position,
+            partition_contributions,
+        ) = best_swap
+        (
+            partitions[first_partition][first_position],
+            partitions[second_partition][second_position],
+        ) = (
+            partitions[second_partition][second_position],
+            partitions[first_partition][first_position],
+        )
+        current_cost = best_cost
+
+
 def stratified_name_split(
     female_proportions: np.ndarray,
     person_counts: np.ndarray,
@@ -165,6 +275,11 @@ def stratified_name_split(
     proportions, counts = _validated_targets_and_weights(
         female_proportions, person_counts
     )
+    if len(counts) < 4:
+        raise ValueError(
+            "At least four usable unique names are required for nonempty training, "
+            "validation, calibration, and test partitions"
+        )
     if count_strata < 1 or proportion_strata < 1:
         raise ValueError("Stratum counts must be positive")
     if not 0 < training_fraction < 1:
@@ -191,31 +306,85 @@ def stratified_name_split(
     )
 
     random_generator = np.random.default_rng(seed)
-    training_indices: list[int] = []
-    validation_indices: list[int] = []
-    calibration_indices: list[int] = []
-    test_indices: list[int] = []
-    validation_boundary = training_fraction + validation_fraction
-    calibration_boundary = validation_boundary + calibration_fraction
+    partition_fractions = np.array(
+        [
+            training_fraction,
+            validation_fraction,
+            calibration_fraction,
+            1 - training_fraction - validation_fraction - calibration_fraction,
+        ]
+    )
+    raw_partition_sizes = partition_fractions * number_of_names
+    partition_sizes = np.floor(raw_partition_sizes).astype(np.int64)
+    unassigned_names = number_of_names - int(partition_sizes.sum())
+    remainder_order = np.argsort(
+        -(raw_partition_sizes - partition_sizes), kind="stable"
+    )
+    partition_sizes[remainder_order[:unassigned_names]] += 1
+    for empty_partition in np.flatnonzero(partition_sizes == 0):
+        donor_partition = int(np.argmax(partition_sizes))
+        partition_sizes[donor_partition] -= 1
+        partition_sizes[empty_partition] = 1
+    allocation_fractions = partition_sizes / number_of_names
+
+    strata: list[tuple[int, np.ndarray]] = []
     for count_bin in range(count_strata):
         for proportion_bin in range(proportion_strata):
             stratum = np.flatnonzero(
                 (count_bins == count_bin) & (proportion_bins == proportion_bin)
             )
+            if len(stratum) == 0:
+                continue
             random_generator.shuffle(stratum)
-            training_end = round(training_fraction * len(stratum))
-            validation_end = round(validation_boundary * len(stratum))
-            calibration_end = round(calibration_boundary * len(stratum))
-            training_indices.extend(stratum[:training_end].tolist())
-            validation_indices.extend(stratum[training_end:validation_end].tolist())
-            calibration_indices.extend(stratum[validation_end:calibration_end].tolist())
-            test_indices.extend(stratum[calibration_end:].tolist())
+            strata.append((count_bin, stratum))
+    random_generator.shuffle(strata)
+    strata.sort(key=lambda item: item[0], reverse=True)
+    allocation_order = np.concatenate([stratum for _, stratum in strata])
+
+    contributions = np.column_stack(
+        (counts, counts * proportions, counts * (1 - proportions))
+    )
+    final_targets = allocation_fractions[:, None] * contributions.sum(axis=0)
+    cost_scale = np.where(final_targets > 0, final_targets, 1)
+    processed_contributions = np.zeros(3, dtype=np.float64)
+    partition_contributions = np.zeros((4, 3), dtype=np.float64)
+    partitions: list[list[int]] = [[], [], [], []]
+    for step, name_index in enumerate(allocation_order, start=1):
+        contribution = contributions[name_index]
+        processed_contributions += contribution
+        running_targets = allocation_fractions[:, None] * processed_contributions
+        running_name_targets = allocation_fractions * step
+        candidate_costs = np.full(4, np.inf)
+        for partition_index in range(4):
+            if len(partitions[partition_index]) >= partition_sizes[partition_index]:
+                continue
+            candidate_contributions = partition_contributions.copy()
+            candidate_contributions[partition_index] += contribution
+            candidate_name_counts = np.asarray(
+                [len(partition) for partition in partitions], dtype=np.float64
+            )
+            candidate_name_counts[partition_index] += 1
+            candidate_costs[partition_index] = (
+                np.square(
+                    (candidate_contributions - running_targets) / cost_scale
+                ).sum()
+                + np.square(
+                    (candidate_name_counts - running_name_targets)
+                    / np.maximum(partition_sizes, 1)
+                ).sum()
+            )
+        selected_partition = int(np.argmin(candidate_costs))
+        partitions[selected_partition].append(int(name_index))
+        partition_contributions[selected_partition] += contribution
+    _refine_partition_balance(
+        partitions, contributions, allocation_fractions, random_generator
+    )
 
     split = NameDatasetSplit(
-        training=np.asarray(training_indices, dtype=np.int64),
-        validation=np.asarray(validation_indices, dtype=np.int64),
-        calibration=np.asarray(calibration_indices, dtype=np.int64),
-        test=np.asarray(test_indices, dtype=np.int64),
+        training=np.asarray(partitions[0], dtype=np.int64),
+        validation=np.asarray(partitions[1], dtype=np.int64),
+        calibration=np.asarray(partitions[2], dtype=np.int64),
+        test=np.asarray(partitions[3], dtype=np.int64),
     )
     split.validate(number_of_names)
     return split
@@ -234,51 +403,70 @@ def probability_metrics(
     if len(predicted_probabilities) != len(targets):
         raise ValueError("probabilities, targets, and weights must have equal lengths")
 
-    observed_labels = targets > 0.5
+    majority_name_labels = targets > 0.5
     predicted_labels = predicted_probabilities > 0.5
-    true_positive_weight = weights[predicted_labels & observed_labels].sum()
-    false_positive_weight = weights[predicted_labels & ~observed_labels].sum()
-    false_negative_weight = weights[~predicted_labels & observed_labels].sum()
-    true_negative_weight = weights[~predicted_labels & ~observed_labels].sum()
+    true_positive_weight = (weights[predicted_labels] * targets[predicted_labels]).sum()
+    false_positive_weight = (
+        weights[predicted_labels] * (1 - targets[predicted_labels])
+    ).sum()
+    false_negative_weight = (
+        weights[~predicted_labels] * targets[~predicted_labels]
+    ).sum()
+    true_negative_weight = (
+        weights[~predicted_labels] * (1 - targets[~predicted_labels])
+    ).sum()
 
-    female_precision = _safe_ratio(
+    expected_female_precision = _safe_ratio(
         true_positive_weight, true_positive_weight + false_positive_weight
     )
-    female_recall = _safe_ratio(
+    expected_female_recall = _safe_ratio(
         true_positive_weight, true_positive_weight + false_negative_weight
     )
-    male_recall = _safe_ratio(
+    expected_male_recall = _safe_ratio(
         true_negative_weight, true_negative_weight + false_positive_weight
     )
-    female_f1 = _safe_ratio(
-        2 * female_precision * female_recall, female_precision + female_recall
+    expected_female_f1 = _safe_ratio(
+        2 * expected_female_precision * expected_female_recall,
+        expected_female_precision + expected_female_recall,
     )
-    brier_score = float(
+    aggregate_composition_mean_squared_error = float(
         np.average(np.square(predicted_probabilities - targets), weights=weights)
     )
+    expected_binary_brier_score = float(
+        np.average(
+            np.square(predicted_probabilities - targets) + targets * (1 - targets),
+            weights=weights,
+        )
+    )
     clipped = np.clip(predicted_probabilities, 1e-7, 1 - 1e-7)
-    soft_log_loss = float(
+    expected_binary_log_loss = float(
         np.average(
             -targets * np.log(clipped) - (1 - targets) * np.log(1 - clipped),
             weights=weights,
         )
     )
     return ProbabilityMetrics(
-        majority_label_accuracy=float(
-            np.average(predicted_labels == observed_labels, weights=weights)
+        majority_name_label_accuracy=float(
+            np.average(predicted_labels == majority_name_labels, weights=weights)
         ),
         expected_person_accuracy=float(
             np.average(
                 np.where(predicted_labels, targets, 1 - targets), weights=weights
             )
         ),
-        female_precision=female_precision,
-        female_recall=female_recall,
-        male_recall=male_recall,
-        female_f1=female_f1,
-        brier_score=brier_score,
-        root_brier_score=float(np.sqrt(brier_score)),
-        soft_log_loss=soft_log_loss,
+        expected_female_precision=expected_female_precision,
+        expected_female_recall=expected_female_recall,
+        expected_male_recall=expected_male_recall,
+        expected_female_f1=expected_female_f1,
+        aggregate_composition_mean_squared_error=(
+            aggregate_composition_mean_squared_error
+        ),
+        aggregate_composition_root_mean_squared_error=float(
+            np.sqrt(aggregate_composition_mean_squared_error)
+        ),
+        expected_binary_brier_score=expected_binary_brier_score,
+        expected_binary_root_brier_score=float(np.sqrt(expected_binary_brier_score)),
+        expected_binary_log_loss=expected_binary_log_loss,
         calibration_error_10_bins=expected_calibration_error(
             predicted_probabilities, targets, weights, number_of_bins=10
         ),
@@ -476,6 +664,20 @@ def bootstrap_metric_intervals(
         }
         for metric_name, metric_value in estimate.items()
     }
+
+
+def name_membership_sha256(names: list[str], indices: np.ndarray) -> str:
+    """Return a canonical SHA-256 digest of a name partition's membership."""
+    selected_indices = np.asarray(indices, dtype=np.int64)
+    if selected_indices.ndim != 1 or len(selected_indices) == 0:
+        raise ValueError("indices must be a nonempty one-dimensional array")
+    if selected_indices.min() < 0 or selected_indices.max() >= len(names):
+        raise ValueError("indices contain an out-of-range value")
+    members = sorted(names[index] for index in selected_indices)
+    encoded = json.dumps(members, ensure_ascii=False, separators=(",", ":")).encode(
+        "utf-8"
+    )
+    return hashlib.sha256(encoded).hexdigest()
 
 
 def _probability_array(name: str, values: np.ndarray) -> np.ndarray:

--- a/model_training/evaluation.py
+++ b/model_training/evaluation.py
@@ -1,0 +1,505 @@
+"""Evaluation contracts for first-name gender-pattern models."""
+
+from __future__ import annotations
+
+import random
+from dataclasses import asdict, dataclass
+from typing import Any
+
+import numpy as np
+import torch
+import torch.nn.functional as torch_functional
+
+
+@dataclass(frozen=True)
+class NameDatasetSplit:
+    """Indices for disjoint model-development partitions."""
+
+    training: np.ndarray
+    validation: np.ndarray
+    calibration: np.ndarray
+    test: np.ndarray
+
+    def validate(self, number_of_names: int) -> None:
+        """Validate that the partitions are disjoint and exhaustive."""
+        combined = np.concatenate(
+            (self.training, self.validation, self.calibration, self.test)
+        )
+        if len(combined) != number_of_names:
+            raise ValueError("Split does not contain every name exactly once")
+        if len(np.unique(combined)) != number_of_names:
+            raise ValueError("Split partitions overlap or contain duplicate indices")
+        if combined.min(initial=0) < 0 or combined.max(initial=-1) >= number_of_names:
+            raise ValueError("Split contains an out-of-range name index")
+
+
+@dataclass(frozen=True)
+class LogisticCalibration:
+    """Logistic calibration applied to a model logit."""
+
+    scale: float
+    intercept: float
+
+    def apply(self, probabilities: np.ndarray) -> np.ndarray:
+        """Return calibrated probabilities."""
+        checked = _probability_array("probabilities", probabilities)
+        clipped = np.clip(checked, 1e-7, 1 - 1e-7)
+        logits = np.log(clipped / (1 - clipped))
+        calibrated_logits = self.scale * logits + self.intercept
+        return 1 / (1 + np.exp(-calibrated_logits))
+
+
+@dataclass(frozen=True)
+class ProbabilityMetrics:
+    """Binary probability and threshold metrics."""
+
+    majority_label_accuracy: float
+    expected_person_accuracy: float
+    female_precision: float
+    female_recall: float
+    male_recall: float
+    female_f1: float
+    brier_score: float
+    root_brier_score: float
+    soft_log_loss: float
+    calibration_error_10_bins: float
+
+    def as_dict(self) -> dict[str, float]:
+        """Return JSON-serializable metric values."""
+        return asdict(self)
+
+
+def legacy_development_split(
+    number_of_names: int, *, seed: int = 0, training_fraction: float = 0.80
+) -> tuple[np.ndarray, np.ndarray]:
+    """Reproduce the split used to train the shipped v0.10.0 checkpoint."""
+    if number_of_names < 2:
+        raise ValueError("At least two names are required")
+    if not 0 < training_fraction < 1:
+        raise ValueError("training_fraction must be between 0 and 1")
+    indices = list(range(number_of_names))
+    legacy_random = random.Random(seed)  # noqa: S311
+    legacy_random.shuffle(indices)
+    cutoff = int(training_fraction * number_of_names)
+    return (
+        np.asarray(indices[:cutoff], dtype=np.int64),
+        np.asarray(indices[cutoff:], dtype=np.int64),
+    )
+
+
+def balanced_calibration_test_split(
+    held_out_indices: np.ndarray,
+    female_proportions: np.ndarray,
+    person_counts: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Balance an existing held-out set into calibration and test halves.
+
+    Names are considered from highest to lowest support. Each name is assigned
+    to the half that minimizes imbalance in name count, represented records,
+    female count, and male count. The algorithm is deterministic.
+    """
+    proportions, counts = _validated_targets_and_weights(
+        female_proportions, person_counts
+    )
+    held_out = np.asarray(held_out_indices, dtype=np.int64)
+    if held_out.ndim != 1 or len(held_out) < 2:
+        raise ValueError("held_out_indices must contain at least two indices")
+    if len(np.unique(held_out)) != len(held_out):
+        raise ValueError("held_out_indices must not contain duplicates")
+    if held_out.min() < 0 or held_out.max() >= len(counts):
+        raise ValueError("held_out_indices contain an out-of-range index")
+
+    target = np.array(
+        [
+            len(held_out) / 2,
+            counts[held_out].sum() / 2,
+            (counts[held_out] * proportions[held_out]).sum() / 2,
+            (counts[held_out] * (1 - proportions[held_out])).sum() / 2,
+        ]
+    )
+    totals = [np.zeros(4), np.zeros(4)]
+    partitions: tuple[list[int], list[int]] = ([], [])
+    ordered = sorted(held_out.tolist(), key=lambda index: (-counts[index], index))
+    for index in ordered:
+        contribution = np.array(
+            [
+                1,
+                counts[index],
+                counts[index] * proportions[index],
+                counts[index] * (1 - proportions[index]),
+            ]
+        )
+        costs = []
+        for side in (0, 1):
+            candidate = [totals[0].copy(), totals[1].copy()]
+            candidate[side] += contribution
+            costs.append(np.square((candidate[0] - candidate[1]) / target).sum())
+        selected_side = 0 if costs[0] <= costs[1] else 1
+        totals[selected_side] += contribution
+        partitions[selected_side].append(index)
+    return (
+        np.asarray(partitions[0], dtype=np.int64),
+        np.asarray(partitions[1], dtype=np.int64),
+    )
+
+
+def stratified_name_split(
+    female_proportions: np.ndarray,
+    person_counts: np.ndarray,
+    *,
+    seed: int = 0,
+    training_fraction: float = 0.70,
+    validation_fraction: float = 0.10,
+    calibration_fraction: float = 0.10,
+    count_strata: int = 100,
+    proportion_strata: int = 10,
+) -> NameDatasetSplit:
+    """Split unique names while balancing support and target proportion.
+
+    Names are ranked into support strata and binned by their observed female
+    proportion. Each stratum is shuffled independently before being allocated
+    to training, validation, calibration, and test partitions. Exact names
+    therefore never cross partitions, while all four retain similar support and
+    target distributions.
+    """
+    proportions, counts = _validated_targets_and_weights(
+        female_proportions, person_counts
+    )
+    if count_strata < 1 or proportion_strata < 1:
+        raise ValueError("Stratum counts must be positive")
+    if not 0 < training_fraction < 1:
+        raise ValueError("training_fraction must be between 0 and 1")
+    if not 0 < validation_fraction < 1 - training_fraction:
+        raise ValueError(
+            "validation_fraction must be positive and leave room for later partitions"
+        )
+    if not 0 < calibration_fraction < 1 - training_fraction - validation_fraction:
+        raise ValueError(
+            "calibration_fraction must be positive and leave a nonempty test fraction"
+        )
+
+    number_of_names = len(counts)
+    count_order = np.argsort(counts, kind="stable")
+    count_rank = np.empty(number_of_names, dtype=np.int64)
+    count_rank[count_order] = np.arange(number_of_names)
+    count_bins = np.minimum(
+        count_rank * count_strata // number_of_names, count_strata - 1
+    )
+    proportion_bins = np.minimum(
+        (proportions * proportion_strata).astype(np.int64),
+        proportion_strata - 1,
+    )
+
+    random_generator = np.random.default_rng(seed)
+    training_indices: list[int] = []
+    validation_indices: list[int] = []
+    calibration_indices: list[int] = []
+    test_indices: list[int] = []
+    validation_boundary = training_fraction + validation_fraction
+    calibration_boundary = validation_boundary + calibration_fraction
+    for count_bin in range(count_strata):
+        for proportion_bin in range(proportion_strata):
+            stratum = np.flatnonzero(
+                (count_bins == count_bin) & (proportion_bins == proportion_bin)
+            )
+            random_generator.shuffle(stratum)
+            training_end = round(training_fraction * len(stratum))
+            validation_end = round(validation_boundary * len(stratum))
+            calibration_end = round(calibration_boundary * len(stratum))
+            training_indices.extend(stratum[:training_end].tolist())
+            validation_indices.extend(stratum[training_end:validation_end].tolist())
+            calibration_indices.extend(stratum[validation_end:calibration_end].tolist())
+            test_indices.extend(stratum[calibration_end:].tolist())
+
+    split = NameDatasetSplit(
+        training=np.asarray(training_indices, dtype=np.int64),
+        validation=np.asarray(validation_indices, dtype=np.int64),
+        calibration=np.asarray(calibration_indices, dtype=np.int64),
+        test=np.asarray(test_indices, dtype=np.int64),
+    )
+    split.validate(number_of_names)
+    return split
+
+
+def probability_metrics(
+    probabilities: np.ndarray,
+    female_proportions: np.ndarray,
+    sample_weights: np.ndarray,
+) -> ProbabilityMetrics:
+    """Compute probability and threshold metrics for soft binary targets."""
+    predicted_probabilities = _probability_array("probabilities", probabilities)
+    targets, weights = _validated_targets_and_weights(
+        female_proportions, sample_weights
+    )
+    if len(predicted_probabilities) != len(targets):
+        raise ValueError("probabilities, targets, and weights must have equal lengths")
+
+    observed_labels = targets > 0.5
+    predicted_labels = predicted_probabilities > 0.5
+    true_positive_weight = weights[predicted_labels & observed_labels].sum()
+    false_positive_weight = weights[predicted_labels & ~observed_labels].sum()
+    false_negative_weight = weights[~predicted_labels & observed_labels].sum()
+    true_negative_weight = weights[~predicted_labels & ~observed_labels].sum()
+
+    female_precision = _safe_ratio(
+        true_positive_weight, true_positive_weight + false_positive_weight
+    )
+    female_recall = _safe_ratio(
+        true_positive_weight, true_positive_weight + false_negative_weight
+    )
+    male_recall = _safe_ratio(
+        true_negative_weight, true_negative_weight + false_positive_weight
+    )
+    female_f1 = _safe_ratio(
+        2 * female_precision * female_recall, female_precision + female_recall
+    )
+    brier_score = float(
+        np.average(np.square(predicted_probabilities - targets), weights=weights)
+    )
+    clipped = np.clip(predicted_probabilities, 1e-7, 1 - 1e-7)
+    soft_log_loss = float(
+        np.average(
+            -targets * np.log(clipped) - (1 - targets) * np.log(1 - clipped),
+            weights=weights,
+        )
+    )
+    return ProbabilityMetrics(
+        majority_label_accuracy=float(
+            np.average(predicted_labels == observed_labels, weights=weights)
+        ),
+        expected_person_accuracy=float(
+            np.average(
+                np.where(predicted_labels, targets, 1 - targets), weights=weights
+            )
+        ),
+        female_precision=female_precision,
+        female_recall=female_recall,
+        male_recall=male_recall,
+        female_f1=female_f1,
+        brier_score=brier_score,
+        root_brier_score=float(np.sqrt(brier_score)),
+        soft_log_loss=soft_log_loss,
+        calibration_error_10_bins=expected_calibration_error(
+            predicted_probabilities, targets, weights, number_of_bins=10
+        ),
+    )
+
+
+def expected_calibration_error(
+    probabilities: np.ndarray,
+    female_proportions: np.ndarray,
+    sample_weights: np.ndarray,
+    *,
+    number_of_bins: int,
+) -> float:
+    """Return weighted absolute calibration error across equal-width bins."""
+    predicted_probabilities = _probability_array("probabilities", probabilities)
+    targets, weights = _validated_targets_and_weights(
+        female_proportions, sample_weights
+    )
+    if len(predicted_probabilities) != len(targets):
+        raise ValueError("probabilities, targets, and weights must have equal lengths")
+    if number_of_bins < 1:
+        raise ValueError("number_of_bins must be positive")
+
+    boundaries = np.linspace(0, 1, number_of_bins + 1)
+    bin_indices = np.minimum(
+        np.digitize(predicted_probabilities, boundaries[1:-1]), number_of_bins - 1
+    )
+    total_weight = weights.sum()
+    calibration_error = 0.0
+    for bin_index in range(number_of_bins):
+        selected = bin_indices == bin_index
+        if not selected.any():
+            continue
+        bin_weight = weights[selected].sum()
+        mean_prediction = np.average(
+            predicted_probabilities[selected], weights=weights[selected]
+        )
+        mean_target = np.average(targets[selected], weights=weights[selected])
+        calibration_error += (
+            bin_weight / total_weight * abs(mean_prediction - mean_target)
+        )
+    return float(calibration_error)
+
+
+def fit_logistic_calibration(
+    probabilities: np.ndarray,
+    female_proportions: np.ndarray,
+    sample_weights: np.ndarray,
+) -> LogisticCalibration:
+    """Fit positive-scale logistic calibration on a held-out partition."""
+    predicted_probabilities = _probability_array("probabilities", probabilities)
+    targets, weights = _validated_targets_and_weights(
+        female_proportions, sample_weights
+    )
+    if len(predicted_probabilities) != len(targets):
+        raise ValueError("probabilities, targets, and weights must have equal lengths")
+
+    clipped = np.clip(predicted_probabilities, 1e-7, 1 - 1e-7)
+    logits = torch.tensor(np.log(clipped / (1 - clipped)), dtype=torch.float64)
+    target_tensor = torch.tensor(targets, dtype=torch.float64)
+    weight_tensor = torch.tensor(weights / weights.sum(), dtype=torch.float64)
+    log_scale = torch.tensor(0.0, dtype=torch.float64, requires_grad=True)
+    intercept = torch.tensor(0.0, dtype=torch.float64, requires_grad=True)
+    optimizer = torch.optim.LBFGS(
+        [log_scale, intercept],
+        max_iter=100,
+        tolerance_grad=1e-12,
+        tolerance_change=1e-12,
+    )
+
+    def closure() -> torch.Tensor:
+        optimizer.zero_grad()
+        calibrated_logits = torch.exp(log_scale) * logits + intercept
+        loss = (
+            torch_functional.binary_cross_entropy_with_logits(
+                calibrated_logits, target_tensor, reduction="none"
+            )
+            * weight_tensor
+        ).sum()
+        loss.backward()
+        return loss
+
+    optimizer.step(closure)
+    return LogisticCalibration(
+        scale=float(torch.exp(log_scale).detach()),
+        intercept=float(intercept.detach()),
+    )
+
+
+def split_summary(
+    split: NameDatasetSplit,
+    female_proportions: np.ndarray,
+    person_counts: np.ndarray,
+) -> dict[str, dict[str, float | int]]:
+    """Summarize support and composition for each split partition."""
+    proportions, counts = _validated_targets_and_weights(
+        female_proportions, person_counts
+    )
+    summary: dict[str, dict[str, float | int]] = {}
+    for partition_name, indices in (
+        ("training", split.training),
+        ("validation", split.validation),
+        ("calibration", split.calibration),
+        ("test", split.test),
+    ):
+        summary[partition_name] = partition_summary(indices, proportions, counts)
+    return summary
+
+
+def partition_summary(
+    indices: np.ndarray,
+    female_proportions: np.ndarray,
+    person_counts: np.ndarray,
+) -> dict[str, float | int]:
+    """Summarize support and composition for one nonempty partition."""
+    proportions, counts = _validated_targets_and_weights(
+        female_proportions, person_counts
+    )
+    selected_indices = np.asarray(indices, dtype=np.int64)
+    if selected_indices.ndim != 1 or len(selected_indices) == 0:
+        raise ValueError("indices must be a nonempty one-dimensional array")
+    if selected_indices.min() < 0 or selected_indices.max() >= len(counts):
+        raise ValueError("indices contain an out-of-range value")
+    selected_counts = counts[selected_indices]
+    total_people = selected_counts.sum()
+    return {
+        "names": len(selected_indices),
+        "people": int(total_people),
+        "female_share": float(
+            np.average(proportions[selected_indices], weights=selected_counts)
+        ),
+        "effective_names": float(total_people**2 / np.square(selected_counts).sum()),
+        "largest_name_share": float(selected_counts.max() / total_people),
+    }
+
+
+def report_metrics(
+    probabilities: np.ndarray,
+    female_proportions: np.ndarray,
+    person_counts: np.ndarray,
+) -> dict[str, dict[str, Any]]:
+    """Return name-weighted and person-weighted metrics."""
+    return {
+        "name_weighted": probability_metrics(
+            probabilities,
+            female_proportions,
+            np.ones_like(person_counts, dtype=np.float64),
+        ).as_dict(),
+        "person_weighted": probability_metrics(
+            probabilities, female_proportions, person_counts
+        ).as_dict(),
+    }
+
+
+def bootstrap_metric_intervals(
+    probabilities: np.ndarray,
+    female_proportions: np.ndarray,
+    sample_weights: np.ndarray,
+    *,
+    iterations: int = 1_000,
+    confidence_level: float = 0.95,
+    seed: int = 0,
+) -> dict[str, dict[str, float]]:
+    """Return name-cluster bootstrap intervals for every reported metric."""
+    predicted_probabilities = _probability_array("probabilities", probabilities)
+    targets, weights = _validated_targets_and_weights(
+        female_proportions, sample_weights
+    )
+    if len(predicted_probabilities) != len(targets):
+        raise ValueError("probabilities, targets, and weights must have equal lengths")
+    if iterations < 2:
+        raise ValueError("iterations must be at least two")
+    if not 0 < confidence_level < 1:
+        raise ValueError("confidence_level must be between 0 and 1")
+
+    estimate = probability_metrics(predicted_probabilities, targets, weights).as_dict()
+    draws = {metric_name: np.empty(iterations) for metric_name in estimate}
+    random_generator = np.random.default_rng(seed)
+    for iteration in range(iterations):
+        sampled_indices = random_generator.integers(0, len(targets), size=len(targets))
+        sampled_metrics = probability_metrics(
+            predicted_probabilities[sampled_indices],
+            targets[sampled_indices],
+            weights[sampled_indices],
+        ).as_dict()
+        for metric_name, metric_value in sampled_metrics.items():
+            draws[metric_name][iteration] = metric_value
+
+    tail_probability = (1 - confidence_level) / 2
+    return {
+        metric_name: {
+            "estimate": metric_value,
+            "lower": float(np.quantile(draws[metric_name], tail_probability)),
+            "upper": float(np.quantile(draws[metric_name], 1 - tail_probability)),
+        }
+        for metric_name, metric_value in estimate.items()
+    }
+
+
+def _probability_array(name: str, values: np.ndarray) -> np.ndarray:
+    array = np.asarray(values, dtype=np.float64)
+    if array.ndim != 1 or len(array) == 0:
+        raise ValueError(f"{name} must be a nonempty one-dimensional array")
+    if not np.isfinite(array).all() or np.any((array < 0) | (array > 1)):
+        raise ValueError(f"{name} must contain finite values between 0 and 1")
+    return array
+
+
+def _validated_targets_and_weights(
+    female_proportions: np.ndarray, sample_weights: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]:
+    targets = _probability_array("female_proportions", female_proportions)
+    weights = np.asarray(sample_weights, dtype=np.float64)
+    if weights.ndim != 1 or len(weights) != len(targets):
+        raise ValueError("sample_weights must be one-dimensional and match the targets")
+    if not np.isfinite(weights).all() or np.any(weights < 0) or weights.sum() <= 0:
+        raise ValueError(
+            "sample_weights must be finite, nonnegative, and sum above zero"
+        )
+    return targets, weights
+
+
+def _safe_ratio(numerator: float, denominator: float) -> float:
+    return float(numerator / denominator) if denominator else 0.0

--- a/model_training/reports/gender_lstm_f7f2b7ac.json
+++ b/model_training/reports/gender_lstm_f7f2b7ac.json
@@ -1,19 +1,24 @@
 {
   "calibration": {
+    "current_runtime_status": "not_applied",
     "fit_partition": "calibration",
     "intercept": -0.059700589542783886,
     "method": "positive-scale logistic calibration",
+    "required_for_calibrated_serving": true,
     "scale": 0.7649909336773688
   },
   "data": {
+    "artifact_encoding": "legacy pandas gzip output predating the canonical deterministic writer",
     "filename": "naampy_v3.csv.gz",
     "sha256": "a548226d9fe4c1dd7193d79487f51e55d77ad58e327b1b58e966b910e484ccf4",
+    "source_row_limit": null,
     "usable_unique_names": 124447
   },
   "evidence_role": "developmental",
   "limitations": [
     "The checkpoint training loop monitored the complete original held-out partition after every epoch; this is not confirmatory evidence.",
-    "The binary model excludes the extremely sparse third-gender label and does not estimate gender identity."
+    "The binary model excludes the extremely sparse third-gender label and does not estimate gender identity.",
+    "The calibration in this report is an offline evaluation transform; the current Naampy runtime serves the raw checkpoint probabilities."
   ],
   "metrics": {
     "balanced_test_calibrated": {
@@ -22,134 +27,159 @@
         "iterations": 1000,
         "method": "name-cluster percentile bootstrap",
         "name_weighted": {
-          "brier_score": {
+          "aggregate_composition_mean_squared_error": {
             "estimate": 0.06716658780807148,
             "lower": 0.06476472432429074,
             "upper": 0.06958258963706934
+          },
+          "aggregate_composition_root_mean_squared_error": {
+            "estimate": 0.2591651747594022,
+            "lower": 0.25448914382303905,
+            "upper": 0.26378511994477144
           },
           "calibration_error_10_bins": {
             "estimate": 0.022460789175934213,
             "lower": 0.018205160174541567,
             "upper": 0.027172608194933893
           },
+          "expected_binary_brier_score": {
+            "estimate": 0.15241101789498912,
+            "lower": 0.14951565093625993,
+            "upper": 0.15537370249844384
+          },
+          "expected_binary_log_loss": {
+            "estimate": 0.45791601154964384,
+            "lower": 0.4502569810610617,
+            "upper": 0.4659992702542095
+          },
+          "expected_binary_root_brier_score": {
+            "estimate": 0.3903985372603093,
+            "lower": 0.38667253708557586,
+            "upper": 0.3941747106075738
+          },
+          "expected_female_f1": {
+            "estimate": 0.7490713075981112,
+            "lower": 0.7424167363294255,
+            "upper": 0.7561571475602369
+          },
+          "expected_female_precision": {
+            "estimate": 0.749958572110561,
+            "lower": 0.7419364545069349,
+            "upper": 0.7583440240723954
+          },
+          "expected_female_recall": {
+            "estimate": 0.7481861400229463,
+            "lower": 0.7390832781347138,
+            "upper": 0.7575992777583892
+          },
+          "expected_male_recall": {
+            "estimate": 0.7753543842612746,
+            "lower": 0.7675591415090405,
+            "upper": 0.7835139870247064
+          },
           "expected_person_accuracy": {
             "estimate": 0.7624809880769549,
             "lower": 0.7574889648163607,
             "upper": 0.7686627816997113
           },
-          "female_f1": {
-            "estimate": 0.786206896551724,
-            "lower": 0.7784474290976596,
-            "upper": 0.7939869154359054
-          },
-          "female_precision": {
-            "estimate": 0.7944926058133606,
-            "lower": 0.7835198165983837,
-            "upper": 0.8044840674744013
-          },
-          "female_recall": {
-            "estimate": 0.7780922257366406,
-            "lower": 0.7679565985791624,
-            "upper": 0.7883734522795016
-          },
-          "majority_label_accuracy": {
+          "majority_name_label_accuracy": {
             "estimate": 0.7957412615508236,
             "lower": 0.7887505022097228,
             "upper": 0.8028143832864604
-          },
-          "male_recall": {
-            "estimate": 0.8122087604846225,
-            "lower": 0.8025141142483527,
-            "upper": 0.8218469747345026
-          },
-          "root_brier_score": {
-            "estimate": 0.2591651747594022,
-            "lower": 0.25448914382303905,
-            "upper": 0.26378511994477144
-          },
-          "soft_log_loss": {
-            "estimate": 0.45791601154964384,
-            "lower": 0.4502569810610617,
-            "upper": 0.4659992702542095
           }
         },
         "person_weighted": {
-          "brier_score": {
+          "aggregate_composition_mean_squared_error": {
             "estimate": 0.03834595385252297,
             "lower": 0.030191087557446004,
             "upper": 0.049144730221487874
+          },
+          "aggregate_composition_root_mean_squared_error": {
+            "estimate": 0.19582122932032414,
+            "lower": 0.17375582705692585,
+            "upper": 0.22168610558128488
           },
           "calibration_error_10_bins": {
             "estimate": 0.03940175495941002,
             "lower": 0.026672044660766326,
             "upper": 0.06824846097637428
           },
+          "expected_binary_brier_score": {
+            "estimate": 0.13549017365331315,
+            "lower": 0.11761108258642455,
+            "upper": 0.15487154011145998
+          },
+          "expected_binary_log_loss": {
+            "estimate": 0.4161854983394013,
+            "lower": 0.3701749633789392,
+            "upper": 0.46644567404172405
+          },
+          "expected_binary_root_brier_score": {
+            "estimate": 0.3680898988743282,
+            "lower": 0.34294472227231654,
+            "upper": 0.3935372138122604
+          },
+          "expected_female_f1": {
+            "estimate": 0.7697711551890016,
+            "lower": 0.7071679674267534,
+            "upper": 0.8202109536874014
+          },
+          "expected_female_precision": {
+            "estimate": 0.7939460739356669,
+            "lower": 0.7389016204395084,
+            "upper": 0.8401669441351777
+          },
+          "expected_female_recall": {
+            "estimate": 0.747024941246724,
+            "lower": 0.657206822098514,
+            "upper": 0.8247047162521671
+          },
+          "expected_male_recall": {
+            "estimate": 0.8261177442035135,
+            "lower": 0.7701048046700789,
+            "upper": 0.871878524328967
+          },
           "expected_person_accuracy": {
             "estimate": 0.7887213864207346,
             "lower": 0.7465521632963346,
             "upper": 0.8258875606060856
           },
-          "female_f1": {
-            "estimate": 0.8044783244122371,
-            "lower": 0.7177159059579986,
-            "upper": 0.874472358624422
-          },
-          "female_precision": {
-            "estimate": 0.8606038100775522,
-            "lower": 0.7819445016042241,
-            "upper": 0.9260764311179266
-          },
-          "female_recall": {
-            "estimate": 0.7552252495137556,
-            "lower": 0.6375471641529266,
-            "upper": 0.864031226735877
-          },
-          "majority_label_accuracy": {
+          "majority_name_label_accuracy": {
             "estimate": 0.8138983346596143,
             "lower": 0.7412718121866413,
             "upper": 0.8795394690347281
-          },
-          "male_recall": {
-            "estimate": 0.8742249803711494,
-            "lower": 0.801038464408421,
-            "upper": 0.9311232720409784
-          },
-          "root_brier_score": {
-            "estimate": 0.19582122932032414,
-            "lower": 0.17375582705692585,
-            "upper": 0.22168610558128488
-          },
-          "soft_log_loss": {
-            "estimate": 0.4161854983394013,
-            "lower": 0.3701749633789392,
-            "upper": 0.46644567404172405
           }
-        }
+        },
+        "seed": 0
       },
       "point_estimates": {
         "name_weighted": {
-          "brier_score": 0.06716658780807148,
+          "aggregate_composition_mean_squared_error": 0.06716658780807148,
+          "aggregate_composition_root_mean_squared_error": 0.2591651747594022,
           "calibration_error_10_bins": 0.022460789175934213,
+          "expected_binary_brier_score": 0.15241101789498912,
+          "expected_binary_log_loss": 0.45791601154964384,
+          "expected_binary_root_brier_score": 0.3903985372603093,
+          "expected_female_f1": 0.7490713075981112,
+          "expected_female_precision": 0.749958572110561,
+          "expected_female_recall": 0.7481861400229463,
+          "expected_male_recall": 0.7753543842612746,
           "expected_person_accuracy": 0.7624809880769549,
-          "female_f1": 0.786206896551724,
-          "female_precision": 0.7944926058133606,
-          "female_recall": 0.7780922257366406,
-          "majority_label_accuracy": 0.7957412615508236,
-          "male_recall": 0.8122087604846225,
-          "root_brier_score": 0.2591651747594022,
-          "soft_log_loss": 0.45791601154964384
+          "majority_name_label_accuracy": 0.7957412615508236
         },
         "person_weighted": {
-          "brier_score": 0.03834595385252297,
+          "aggregate_composition_mean_squared_error": 0.03834595385252297,
+          "aggregate_composition_root_mean_squared_error": 0.19582122932032414,
           "calibration_error_10_bins": 0.03940175495941002,
+          "expected_binary_brier_score": 0.13549017365331315,
+          "expected_binary_log_loss": 0.4161854983394013,
+          "expected_binary_root_brier_score": 0.3680898988743282,
+          "expected_female_f1": 0.7697711551890016,
+          "expected_female_precision": 0.7939460739356669,
+          "expected_female_recall": 0.747024941246724,
+          "expected_male_recall": 0.8261177442035135,
           "expected_person_accuracy": 0.7887213864207346,
-          "female_f1": 0.8044783244122371,
-          "female_precision": 0.8606038100775522,
-          "female_recall": 0.7552252495137556,
-          "majority_label_accuracy": 0.8138983346596143,
-          "male_recall": 0.8742249803711494,
-          "root_brier_score": 0.19582122932032414,
-          "soft_log_loss": 0.4161854983394013
+          "majority_name_label_accuracy": 0.8138983346596143
         }
       }
     },
@@ -159,161 +189,190 @@
         "iterations": 1000,
         "method": "name-cluster percentile bootstrap",
         "name_weighted": {
-          "brier_score": {
+          "aggregate_composition_mean_squared_error": {
             "estimate": 0.07060657040544609,
             "lower": 0.06794300427020415,
             "upper": 0.07325006902150737
+          },
+          "aggregate_composition_root_mean_squared_error": {
+            "estimate": 0.26571896884762686,
+            "lower": 0.26065878891537314,
+            "upper": 0.2706474990000904
           },
           "calibration_error_10_bins": {
             "estimate": 0.05458435038156771,
             "lower": 0.05066605913065222,
             "upper": 0.05941925728203238
           },
+          "expected_binary_brier_score": {
+            "estimate": 0.15585100049236372,
+            "lower": 0.1526736596581519,
+            "upper": 0.15913191941573945
+          },
+          "expected_binary_log_loss": {
+            "estimate": 0.4762268788802939,
+            "lower": 0.46680381795578957,
+            "upper": 0.48640794168988777
+          },
+          "expected_binary_root_brier_score": {
+            "estimate": 0.39477968601786456,
+            "lower": 0.39073476882402386,
+            "upper": 0.3989134234456606
+          },
+          "expected_female_f1": {
+            "estimate": 0.753473264138076,
+            "lower": 0.7471672549938165,
+            "upper": 0.7604730129961851
+          },
+          "expected_female_precision": {
+            "estimate": 0.7375018249694846,
+            "lower": 0.7297432557017051,
+            "upper": 0.7460427765777173
+          },
+          "expected_female_recall": {
+            "estimate": 0.7701517750368008,
+            "lower": 0.7610758719872073,
+            "upper": 0.7793538913668161
+          },
+          "expected_male_recall": {
+            "estimate": 0.7531386490012472,
+            "lower": 0.7450784894504331,
+            "upper": 0.7621914320764437
+          },
           "expected_person_accuracy": {
             "estimate": 0.7612001457202903,
             "lower": 0.7561412068092785,
             "upper": 0.7672280689870974
           },
-          "female_f1": {
-            "estimate": 0.7924373201808467,
-            "lower": 0.7843611285327421,
-            "upper": 0.8004553539104303
-          },
-          "female_precision": {
-            "estimate": 0.7827216628775576,
-            "lower": 0.7725844177997,
-            "upper": 0.7931092169354487
-          },
-          "female_recall": {
-            "estimate": 0.80239720326286,
-            "lower": 0.792145091151738,
-            "upper": 0.8122233703763146
-          },
-          "majority_label_accuracy": {
+          "majority_name_label_accuracy": {
             "estimate": 0.7971072719967859,
             "lower": 0.7900361591000402,
             "upper": 0.8041803937324227
-          },
-          "male_recall": {
-            "estimate": 0.7921714818266542,
-            "lower": 0.7828985323652718,
-            "upper": 0.8022534626874533
-          },
-          "root_brier_score": {
-            "estimate": 0.26571896884762686,
-            "lower": 0.26065878891537314,
-            "upper": 0.2706474990000904
-          },
-          "soft_log_loss": {
-            "estimate": 0.4762268788802939,
-            "lower": 0.46680381795578957,
-            "upper": 0.48640794168988777
           }
         },
         "person_weighted": {
-          "brier_score": {
+          "aggregate_composition_mean_squared_error": {
             "estimate": 0.0396636611337792,
             "lower": 0.030127302826285684,
             "upper": 0.052402039125348965
+          },
+          "aggregate_composition_root_mean_squared_error": {
+            "estimate": 0.19915737780403517,
+            "lower": 0.1735721823770633,
+            "upper": 0.22891491483389903
           },
           "calibration_error_10_bins": {
             "estimate": 0.05084782459792093,
             "lower": 0.032838183324983235,
             "upper": 0.0779162508793914
           },
+          "expected_binary_brier_score": {
+            "estimate": 0.13680788093456933,
+            "lower": 0.11742278808415225,
+            "upper": 0.15771951804261272
+          },
+          "expected_binary_log_loss": {
+            "estimate": 0.42530193590263954,
+            "lower": 0.37141623852350736,
+            "upper": 0.48330120043313024
+          },
+          "expected_binary_root_brier_score": {
+            "estimate": 0.36987549382808443,
+            "lower": 0.342670086307484,
+            "upper": 0.39713916649828235
+          },
+          "expected_female_f1": {
+            "estimate": 0.7738507653703209,
+            "lower": 0.7120434617226248,
+            "upper": 0.8221688325427815
+          },
+          "expected_female_precision": {
+            "estimate": 0.7826669138037091,
+            "lower": 0.7279479722104504,
+            "upper": 0.8291405774483374
+          },
+          "expected_female_recall": {
+            "estimate": 0.7652310190506554,
+            "lower": 0.6772639616992654,
+            "upper": 0.8419905151618654
+          },
+          "expected_male_recall": {
+            "estimate": 0.8094224613758,
+            "lower": 0.7541637172499694,
+            "upper": 0.8571717168372305
+          },
           "expected_person_accuracy": {
             "estimate": 0.7885280319669573,
             "lower": 0.7460310908505821,
             "upper": 0.8255865372908866
           },
-          "female_f1": {
-            "estimate": 0.8106555330834931,
-            "lower": 0.7268777639112611,
-            "upper": 0.8815030465122244
-          },
-          "female_precision": {
-            "estimate": 0.8498173873021332,
-            "lower": 0.7723624278542167,
-            "upper": 0.9168409960726999
-          },
-          "female_recall": {
-            "estimate": 0.7749440425048824,
-            "lower": 0.6544995673842119,
-            "upper": 0.8850200886306496
-          },
-          "majority_label_accuracy": {
+          "majority_name_label_accuracy": {
             "estimate": 0.8164815189536702,
             "lower": 0.7415874569003075,
             "upper": 0.8829256908436199
-          },
-          "male_recall": {
-            "estimate": 0.8591896298233799,
-            "lower": 0.7825177909081522,
-            "upper": 0.9194408220710932
-          },
-          "root_brier_score": {
-            "estimate": 0.19915737780403517,
-            "lower": 0.1735721823770633,
-            "upper": 0.22891491483389903
-          },
-          "soft_log_loss": {
-            "estimate": 0.42530193590263954,
-            "lower": 0.37141623852350736,
-            "upper": 0.48330120043313024
           }
-        }
+        },
+        "seed": 0
       },
       "point_estimates": {
         "name_weighted": {
-          "brier_score": 0.07060657040544609,
+          "aggregate_composition_mean_squared_error": 0.07060657040544609,
+          "aggregate_composition_root_mean_squared_error": 0.26571896884762686,
           "calibration_error_10_bins": 0.05458435038156771,
+          "expected_binary_brier_score": 0.15585100049236372,
+          "expected_binary_log_loss": 0.4762268788802939,
+          "expected_binary_root_brier_score": 0.39477968601786456,
+          "expected_female_f1": 0.753473264138076,
+          "expected_female_precision": 0.7375018249694846,
+          "expected_female_recall": 0.7701517750368008,
+          "expected_male_recall": 0.7531386490012472,
           "expected_person_accuracy": 0.7612001457202903,
-          "female_f1": 0.7924373201808467,
-          "female_precision": 0.7827216628775576,
-          "female_recall": 0.80239720326286,
-          "majority_label_accuracy": 0.7971072719967859,
-          "male_recall": 0.7921714818266542,
-          "root_brier_score": 0.26571896884762686,
-          "soft_log_loss": 0.4762268788802939
+          "majority_name_label_accuracy": 0.7971072719967859
         },
         "person_weighted": {
-          "brier_score": 0.0396636611337792,
+          "aggregate_composition_mean_squared_error": 0.0396636611337792,
+          "aggregate_composition_root_mean_squared_error": 0.19915737780403517,
           "calibration_error_10_bins": 0.05084782459792093,
+          "expected_binary_brier_score": 0.13680788093456933,
+          "expected_binary_log_loss": 0.42530193590263954,
+          "expected_binary_root_brier_score": 0.36987549382808443,
+          "expected_female_f1": 0.7738507653703209,
+          "expected_female_precision": 0.7826669138037091,
+          "expected_female_recall": 0.7652310190506554,
+          "expected_male_recall": 0.8094224613758,
           "expected_person_accuracy": 0.7885280319669573,
-          "female_f1": 0.8106555330834931,
-          "female_precision": 0.8498173873021332,
-          "female_recall": 0.7749440425048824,
-          "majority_label_accuracy": 0.8164815189536702,
-          "male_recall": 0.8591896298233799,
-          "root_brier_score": 0.19915737780403517,
-          "soft_log_loss": 0.42530193590263954
+          "majority_name_label_accuracy": 0.8164815189536702
         }
       }
     },
     "original_held_out_raw": {
       "name_weighted": {
-        "brier_score": 0.07238066037853541,
+        "aggregate_composition_mean_squared_error": 0.07238066037853541,
+        "aggregate_composition_root_mean_squared_error": 0.26903654097266305,
         "calibration_error_10_bins": 0.054935470632450356,
+        "expected_binary_brier_score": 0.15680370978693953,
+        "expected_binary_log_loss": 0.4792904902924619,
+        "expected_binary_root_brier_score": 0.3959844817501559,
+        "expected_female_f1": 0.7511969260747893,
+        "expected_female_precision": 0.7365942264594453,
+        "expected_female_recall": 0.7663903219189048,
+        "expected_male_recall": 0.7531892929206618,
         "expected_person_accuracy": 0.7594444921014692,
-        "female_f1": 0.7881289470425559,
-        "female_precision": 0.7780132018580392,
-        "female_recall": 0.7985112077617933,
-        "majority_label_accuracy": 0.7937725994375251,
-        "male_recall": 0.7893922993660121,
-        "root_brier_score": 0.26903654097266305,
-        "soft_log_loss": 0.4792904902924619
+        "majority_name_label_accuracy": 0.7937725994375251
       },
       "person_weighted": {
-        "brier_score": 0.03841284377779374,
+        "aggregate_composition_mean_squared_error": 0.03841284377779374,
+        "aggregate_composition_root_mean_squared_error": 0.19599194824735464,
         "calibration_error_10_bins": 0.03699651961961051,
+        "expected_binary_brier_score": 0.12665119294084742,
+        "expected_binary_log_loss": 0.3981921819542204,
+        "expected_binary_root_brier_score": 0.3558808690290157,
+        "expected_female_f1": 0.8016540518202026,
+        "expected_female_precision": 0.7992229806358035,
+        "expected_female_recall": 0.8040999577614142,
+        "expected_male_recall": 0.8188299668735192,
         "expected_person_accuracy": 0.8118653800005381,
-        "female_f1": 0.8415246756723139,
-        "female_precision": 0.8586503190479319,
-        "female_recall": 0.8250688101248456,
-        "majority_label_accuracy": 0.8461577772131452,
-        "male_recall": 0.8668343624011621,
-        "root_brier_score": 0.19599194824735464,
-        "soft_log_loss": 0.3981921819542204
+        "majority_name_label_accuracy": 0.8461577772131452
       }
     }
   },
@@ -327,15 +386,28 @@
       "vocabulary_size": 27
     },
     "filename": "gender_lstm.pt",
-    "hugging_face_repository": "gojiberries/naampy",
-    "hugging_face_revision": "f7f2b7ac62a17f9bbfd102bf88388f1e3da5322a",
+    "provenance": {
+      "repository": "gojiberries/naampy",
+      "revision": "f7f2b7ac62a17f9bbfd102bf88388f1e3da5322a",
+      "source": "hugging_face_hub"
+    },
     "sha256": "98fdcfe9016b48e3a2639c6f2c55eb9d2a56946a51dea6ac0a0c64fafc33b9f7"
   },
   "reference_population": "aggregated Indian electoral-roll registration records represented in the local naampy v3 construction",
-  "schema_version": 1,
+  "schema_version": 2,
   "split": {
+    "membership_provenance": {
+      "fixed_seed": 0,
+      "recipe": "Python random.Random shuffle followed by an 80/20 cutoff",
+      "source": "shipped checkpoint training recipe"
+    },
+    "membership_sha256": {
+      "calibration": "ccb26fe553389f102d19f9bc9ebe7efd24135b5c5bc9c2ef8a29574d1bf125a8",
+      "original_held_out": "8178cc0f05f61da47a4ec196b2d49ce8b727731464e4ca77455988ee0ea3a213",
+      "original_training": "9f25b0ef8fa7427bad162c14e78407435c5314474349efcd8312a406a60dd769",
+      "test": "bb6153794fdfc5562bbf478135a540f807e292153ef54120936520955314722c"
+    },
     "method": "original seeded 80/20 unique-name split; held-out names balanced into calibration and test halves by support and label composition",
-    "seed": 0,
     "summary": {
       "calibration": {
         "effective_names": 151.22503823949518,

--- a/model_training/reports/gender_lstm_f7f2b7ac.json
+++ b/model_training/reports/gender_lstm_f7f2b7ac.json
@@ -1,0 +1,364 @@
+{
+  "calibration": {
+    "fit_partition": "calibration",
+    "intercept": -0.059700589542783886,
+    "method": "positive-scale logistic calibration",
+    "scale": 0.7649909336773688
+  },
+  "data": {
+    "filename": "naampy_v3.csv.gz",
+    "sha256": "a548226d9fe4c1dd7193d79487f51e55d77ad58e327b1b58e966b910e484ccf4",
+    "usable_unique_names": 124447
+  },
+  "evidence_role": "developmental",
+  "limitations": [
+    "The checkpoint training loop monitored the complete original held-out partition after every epoch; this is not confirmatory evidence.",
+    "The binary model excludes the extremely sparse third-gender label and does not estimate gender identity."
+  ],
+  "metrics": {
+    "balanced_test_calibrated": {
+      "intervals": {
+        "confidence_level": 0.95,
+        "iterations": 1000,
+        "method": "name-cluster percentile bootstrap",
+        "name_weighted": {
+          "brier_score": {
+            "estimate": 0.06716658780807148,
+            "lower": 0.06476472432429074,
+            "upper": 0.06958258963706934
+          },
+          "calibration_error_10_bins": {
+            "estimate": 0.022460789175934213,
+            "lower": 0.018205160174541567,
+            "upper": 0.027172608194933893
+          },
+          "expected_person_accuracy": {
+            "estimate": 0.7624809880769549,
+            "lower": 0.7574889648163607,
+            "upper": 0.7686627816997113
+          },
+          "female_f1": {
+            "estimate": 0.786206896551724,
+            "lower": 0.7784474290976596,
+            "upper": 0.7939869154359054
+          },
+          "female_precision": {
+            "estimate": 0.7944926058133606,
+            "lower": 0.7835198165983837,
+            "upper": 0.8044840674744013
+          },
+          "female_recall": {
+            "estimate": 0.7780922257366406,
+            "lower": 0.7679565985791624,
+            "upper": 0.7883734522795016
+          },
+          "majority_label_accuracy": {
+            "estimate": 0.7957412615508236,
+            "lower": 0.7887505022097228,
+            "upper": 0.8028143832864604
+          },
+          "male_recall": {
+            "estimate": 0.8122087604846225,
+            "lower": 0.8025141142483527,
+            "upper": 0.8218469747345026
+          },
+          "root_brier_score": {
+            "estimate": 0.2591651747594022,
+            "lower": 0.25448914382303905,
+            "upper": 0.26378511994477144
+          },
+          "soft_log_loss": {
+            "estimate": 0.45791601154964384,
+            "lower": 0.4502569810610617,
+            "upper": 0.4659992702542095
+          }
+        },
+        "person_weighted": {
+          "brier_score": {
+            "estimate": 0.03834595385252297,
+            "lower": 0.030191087557446004,
+            "upper": 0.049144730221487874
+          },
+          "calibration_error_10_bins": {
+            "estimate": 0.03940175495941002,
+            "lower": 0.026672044660766326,
+            "upper": 0.06824846097637428
+          },
+          "expected_person_accuracy": {
+            "estimate": 0.7887213864207346,
+            "lower": 0.7465521632963346,
+            "upper": 0.8258875606060856
+          },
+          "female_f1": {
+            "estimate": 0.8044783244122371,
+            "lower": 0.7177159059579986,
+            "upper": 0.874472358624422
+          },
+          "female_precision": {
+            "estimate": 0.8606038100775522,
+            "lower": 0.7819445016042241,
+            "upper": 0.9260764311179266
+          },
+          "female_recall": {
+            "estimate": 0.7552252495137556,
+            "lower": 0.6375471641529266,
+            "upper": 0.864031226735877
+          },
+          "majority_label_accuracy": {
+            "estimate": 0.8138983346596143,
+            "lower": 0.7412718121866413,
+            "upper": 0.8795394690347281
+          },
+          "male_recall": {
+            "estimate": 0.8742249803711494,
+            "lower": 0.801038464408421,
+            "upper": 0.9311232720409784
+          },
+          "root_brier_score": {
+            "estimate": 0.19582122932032414,
+            "lower": 0.17375582705692585,
+            "upper": 0.22168610558128488
+          },
+          "soft_log_loss": {
+            "estimate": 0.4161854983394013,
+            "lower": 0.3701749633789392,
+            "upper": 0.46644567404172405
+          }
+        }
+      },
+      "point_estimates": {
+        "name_weighted": {
+          "brier_score": 0.06716658780807148,
+          "calibration_error_10_bins": 0.022460789175934213,
+          "expected_person_accuracy": 0.7624809880769549,
+          "female_f1": 0.786206896551724,
+          "female_precision": 0.7944926058133606,
+          "female_recall": 0.7780922257366406,
+          "majority_label_accuracy": 0.7957412615508236,
+          "male_recall": 0.8122087604846225,
+          "root_brier_score": 0.2591651747594022,
+          "soft_log_loss": 0.45791601154964384
+        },
+        "person_weighted": {
+          "brier_score": 0.03834595385252297,
+          "calibration_error_10_bins": 0.03940175495941002,
+          "expected_person_accuracy": 0.7887213864207346,
+          "female_f1": 0.8044783244122371,
+          "female_precision": 0.8606038100775522,
+          "female_recall": 0.7552252495137556,
+          "majority_label_accuracy": 0.8138983346596143,
+          "male_recall": 0.8742249803711494,
+          "root_brier_score": 0.19582122932032414,
+          "soft_log_loss": 0.4161854983394013
+        }
+      }
+    },
+    "balanced_test_raw": {
+      "intervals": {
+        "confidence_level": 0.95,
+        "iterations": 1000,
+        "method": "name-cluster percentile bootstrap",
+        "name_weighted": {
+          "brier_score": {
+            "estimate": 0.07060657040544609,
+            "lower": 0.06794300427020415,
+            "upper": 0.07325006902150737
+          },
+          "calibration_error_10_bins": {
+            "estimate": 0.05458435038156771,
+            "lower": 0.05066605913065222,
+            "upper": 0.05941925728203238
+          },
+          "expected_person_accuracy": {
+            "estimate": 0.7612001457202903,
+            "lower": 0.7561412068092785,
+            "upper": 0.7672280689870974
+          },
+          "female_f1": {
+            "estimate": 0.7924373201808467,
+            "lower": 0.7843611285327421,
+            "upper": 0.8004553539104303
+          },
+          "female_precision": {
+            "estimate": 0.7827216628775576,
+            "lower": 0.7725844177997,
+            "upper": 0.7931092169354487
+          },
+          "female_recall": {
+            "estimate": 0.80239720326286,
+            "lower": 0.792145091151738,
+            "upper": 0.8122233703763146
+          },
+          "majority_label_accuracy": {
+            "estimate": 0.7971072719967859,
+            "lower": 0.7900361591000402,
+            "upper": 0.8041803937324227
+          },
+          "male_recall": {
+            "estimate": 0.7921714818266542,
+            "lower": 0.7828985323652718,
+            "upper": 0.8022534626874533
+          },
+          "root_brier_score": {
+            "estimate": 0.26571896884762686,
+            "lower": 0.26065878891537314,
+            "upper": 0.2706474990000904
+          },
+          "soft_log_loss": {
+            "estimate": 0.4762268788802939,
+            "lower": 0.46680381795578957,
+            "upper": 0.48640794168988777
+          }
+        },
+        "person_weighted": {
+          "brier_score": {
+            "estimate": 0.0396636611337792,
+            "lower": 0.030127302826285684,
+            "upper": 0.052402039125348965
+          },
+          "calibration_error_10_bins": {
+            "estimate": 0.05084782459792093,
+            "lower": 0.032838183324983235,
+            "upper": 0.0779162508793914
+          },
+          "expected_person_accuracy": {
+            "estimate": 0.7885280319669573,
+            "lower": 0.7460310908505821,
+            "upper": 0.8255865372908866
+          },
+          "female_f1": {
+            "estimate": 0.8106555330834931,
+            "lower": 0.7268777639112611,
+            "upper": 0.8815030465122244
+          },
+          "female_precision": {
+            "estimate": 0.8498173873021332,
+            "lower": 0.7723624278542167,
+            "upper": 0.9168409960726999
+          },
+          "female_recall": {
+            "estimate": 0.7749440425048824,
+            "lower": 0.6544995673842119,
+            "upper": 0.8850200886306496
+          },
+          "majority_label_accuracy": {
+            "estimate": 0.8164815189536702,
+            "lower": 0.7415874569003075,
+            "upper": 0.8829256908436199
+          },
+          "male_recall": {
+            "estimate": 0.8591896298233799,
+            "lower": 0.7825177909081522,
+            "upper": 0.9194408220710932
+          },
+          "root_brier_score": {
+            "estimate": 0.19915737780403517,
+            "lower": 0.1735721823770633,
+            "upper": 0.22891491483389903
+          },
+          "soft_log_loss": {
+            "estimate": 0.42530193590263954,
+            "lower": 0.37141623852350736,
+            "upper": 0.48330120043313024
+          }
+        }
+      },
+      "point_estimates": {
+        "name_weighted": {
+          "brier_score": 0.07060657040544609,
+          "calibration_error_10_bins": 0.05458435038156771,
+          "expected_person_accuracy": 0.7612001457202903,
+          "female_f1": 0.7924373201808467,
+          "female_precision": 0.7827216628775576,
+          "female_recall": 0.80239720326286,
+          "majority_label_accuracy": 0.7971072719967859,
+          "male_recall": 0.7921714818266542,
+          "root_brier_score": 0.26571896884762686,
+          "soft_log_loss": 0.4762268788802939
+        },
+        "person_weighted": {
+          "brier_score": 0.0396636611337792,
+          "calibration_error_10_bins": 0.05084782459792093,
+          "expected_person_accuracy": 0.7885280319669573,
+          "female_f1": 0.8106555330834931,
+          "female_precision": 0.8498173873021332,
+          "female_recall": 0.7749440425048824,
+          "majority_label_accuracy": 0.8164815189536702,
+          "male_recall": 0.8591896298233799,
+          "root_brier_score": 0.19915737780403517,
+          "soft_log_loss": 0.42530193590263954
+        }
+      }
+    },
+    "original_held_out_raw": {
+      "name_weighted": {
+        "brier_score": 0.07238066037853541,
+        "calibration_error_10_bins": 0.054935470632450356,
+        "expected_person_accuracy": 0.7594444921014692,
+        "female_f1": 0.7881289470425559,
+        "female_precision": 0.7780132018580392,
+        "female_recall": 0.7985112077617933,
+        "majority_label_accuracy": 0.7937725994375251,
+        "male_recall": 0.7893922993660121,
+        "root_brier_score": 0.26903654097266305,
+        "soft_log_loss": 0.4792904902924619
+      },
+      "person_weighted": {
+        "brier_score": 0.03841284377779374,
+        "calibration_error_10_bins": 0.03699651961961051,
+        "expected_person_accuracy": 0.8118653800005381,
+        "female_f1": 0.8415246756723139,
+        "female_precision": 0.8586503190479319,
+        "female_recall": 0.8250688101248456,
+        "majority_label_accuracy": 0.8461577772131452,
+        "male_recall": 0.8668343624011621,
+        "root_brier_score": 0.19599194824735464,
+        "soft_log_loss": 0.3981921819542204
+      }
+    }
+  },
+  "model": {
+    "architecture": {
+      "dropout": 0.2,
+      "embedding_dimension": 64,
+      "hidden_dimension": 256,
+      "layers": 2,
+      "type": "character_bidirectional_lstm",
+      "vocabulary_size": 27
+    },
+    "filename": "gender_lstm.pt",
+    "hugging_face_repository": "gojiberries/naampy",
+    "hugging_face_revision": "f7f2b7ac62a17f9bbfd102bf88388f1e3da5322a",
+    "sha256": "98fdcfe9016b48e3a2639c6f2c55eb9d2a56946a51dea6ac0a0c64fafc33b9f7"
+  },
+  "reference_population": "aggregated Indian electoral-roll registration records represented in the local naampy v3 construction",
+  "schema_version": 1,
+  "split": {
+    "method": "original seeded 80/20 unique-name split; held-out names balanced into calibration and test halves by support and label composition",
+    "seed": 0,
+    "summary": {
+      "calibration": {
+        "effective_names": 151.22503823949518,
+        "female_share": 0.4728162012586306,
+        "largest_name_share": 0.039996193491867005,
+        "names": 12445,
+        "people": 43577997
+      },
+      "original_training": {
+        "effective_names": 935.442264703686,
+        "female_share": 0.48318094022958774,
+        "largest_name_share": 0.008703714422704158,
+        "names": 99557,
+        "people": 378023777
+      },
+      "test": {
+        "effective_names": 159.18571051879906,
+        "female_share": 0.4728161904087471,
+        "largest_name_share": 0.03463793816319878,
+        "names": 12445,
+        "people": 43577998
+      }
+    }
+  },
+  "target": "female share among female and male electoral-roll labels"
+}

--- a/model_training/retransliterate_native.py
+++ b/model_training/retransliterate_native.py
@@ -14,12 +14,15 @@ Run in eroll's 3.13 venv (has ``eroll`` + the corpora under ``eroll_transliterat
 import argparse
 import csv
 import gzip
+import logging
 import re
 import unicodedata
 from pathlib import Path
 
 import pandas as pd
 from eroll.states import STATES
+
+LOGGER = logging.getLogger(__name__)
 
 # naampy state slug -> eroll corpus language.
 NAAMPY_STATE2LANG = {
@@ -50,7 +53,7 @@ def to_ascii(s: str) -> str:
 
 
 def _lang_config():
-    """language -> (corpus_csv Path, native_run regex), taken from the eroll STATES registry."""
+    """Return language-specific corpus paths and native-script patterns."""
     out: dict[str, tuple[Path, re.Pattern[str]]] = {}
     for cfg in STATES.values():
         out.setdefault(cfg.language, (cfg.corpus_csv, cfg.native_run))
@@ -77,6 +80,7 @@ def romanize(name: str, word_map: dict[str, str], native_run: re.Pattern[str]) -
 
 
 def main() -> None:
+    """Retransliterate native names and write the aggregated v3 table."""
     ap = argparse.ArgumentParser()
     ap.add_argument("--native", required=True, help="naampy v2_native csv.gz")
     ap.add_argument("--out", required=True, help="output v3 csv.gz")
@@ -97,9 +101,11 @@ def main() -> None:
         states = [s for s, lng in NAAMPY_STATE2LANG.items() if lng == lang]
         mask = df.state.isin(states)
         corpus_csv, native_run = langcfg[lang]
-        print(
-            f"[{lang}] loading {corpus_csv.name} for {len(states)} states ...",
-            flush=True,
+        LOGGER.info(
+            "Loading %s for %s %s states",
+            corpus_csv.name,
+            len(states),
+            lang,
         )
         word_map = _load_word_map(corpus_csv)
         uniq = df.loc[mask, "first_name"].dropna().unique()
@@ -109,9 +115,11 @@ def main() -> None:
         kept = df.loc[mask & (df.fn_en != "")]
         wt = df.loc[mask, ["n_female", "n_male", "n_third_gender"]].to_numpy().sum()
         wtk = kept[["n_female", "n_male", "n_third_gender"]].to_numpy().sum()
-        print(
-            f"[{lang}] {len(uniq):,} uniq names; weight kept {wtk / max(1, wt):.1%}",
-            flush=True,
+        LOGGER.info(
+            "%s: %s unique names; retained %.1f%% of represented records",
+            lang,
+            f"{len(uniq):,}",
+            100 * wtk / max(1, wt),
         )
 
     # Keep rows with a valid English name (len>2), re-aggregate, recompute prop_female.
@@ -126,10 +134,10 @@ def main() -> None:
     if args.v2:  # keep v2's non-native states for full coverage; native states use v3
         v2 = pd.read_csv(args.v2, dtype={"first_name": str})
         others = v2[~v2.state.isin(NAAMPY_STATE2LANG)]
-        print(
-            f"[merge] v3 native {agg.state.nunique()} states + v2 "
-            f"{others.state.nunique()} non-native states",
-            flush=True,
+        LOGGER.info(
+            "Combining %s retransliterated states with %s v2 states",
+            agg.state.nunique(),
+            others.state.nunique(),
         )
         agg = pd.concat([agg, others[agg.columns]], ignore_index=True)
 
@@ -137,12 +145,14 @@ def main() -> None:
     outp = Path(args.out)
     outp.parent.mkdir(parents=True, exist_ok=True)
     agg.to_csv(outp, index=False, compression="gzip")
-    print(
-        f"[v3] {len(agg):,} (state,year,first_name_en) rows "
-        f"({agg.first_name.nunique():,} unique english names) -> {outp}",
-        flush=True,
+    LOGGER.info(
+        "Wrote %s state-year-name rows and %s unique English names to %s",
+        f"{len(agg):,}",
+        f"{agg.first_name.nunique():,}",
+        outp,
     )
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
     main()

--- a/model_training/retransliterate_native.py
+++ b/model_training/retransliterate_native.py
@@ -8,19 +8,22 @@ English first-name->gender dataset (no roll re-harvest).
 Run in eroll's 3.13 venv (has ``eroll`` + the corpora under ``eroll_transliteration/data/``):
 
     .../eroll_transliteration/.venv/bin/python retransliterate_native.py \
-        --native /tmp/naampy_v2_native.csv.gz --out model_training/data/naampy_v3.csv.gz
+        --native /tmp/naampy_v2_native.csv.gz \
+        --v2 /tmp/naampy_v2.csv.gz \
+        --out model_training/data/naampy_v3.csv.gz
 """
 
 import argparse
 import csv
 import gzip
+import io
 import logging
 import re
+import tempfile
 import unicodedata
 from pathlib import Path
 
 import pandas as pd
-from eroll.states import STATES
 
 LOGGER = logging.getLogger(__name__)
 
@@ -54,6 +57,8 @@ def to_ascii(s: str) -> str:
 
 def _lang_config():
     """Return language-specific corpus paths and native-script patterns."""
+    from eroll.states import STATES
+
     out: dict[str, tuple[Path, re.Pattern[str]]] = {}
     for cfg in STATES.values():
         out.setdefault(cfg.language, (cfg.corpus_csv, cfg.native_run))
@@ -69,6 +74,42 @@ def _load_word_map(corpus_csv) -> dict[str, str]:
             if len(row) >= 2:
                 word_map[row[0]] = row[1]
     return word_map
+
+
+def write_deterministic_gzip_csv(table: pd.DataFrame, output_path: Path) -> None:
+    """Write a canonical gzip-compressed CSV atomically."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        dir=output_path.parent,
+        prefix=f".{output_path.name}.",
+        suffix=".tmp",
+        delete=False,
+    ) as temporary_file:
+        temporary_path = Path(temporary_file.name)
+    try:
+        with (
+            temporary_path.open("wb") as raw_output,
+            gzip.GzipFile(
+                filename="",
+                mode="wb",
+                compresslevel=9,
+                fileobj=raw_output,
+                mtime=0,
+            ) as compressed_output,
+            io.TextIOWrapper(
+                compressed_output, encoding="utf-8", newline=""
+            ) as text_output,
+        ):
+            table.to_csv(
+                text_output,
+                index=False,
+                float_format="%.17g",
+                lineterminator="\n",
+            )
+        temporary_path.replace(output_path)
+        output_path.chmod(0o644)
+    finally:
+        temporary_path.unlink(missing_ok=True)
 
 
 def romanize(name: str, word_map: dict[str, str], native_run: re.Pattern[str]) -> str:
@@ -141,10 +182,11 @@ def main() -> None:
         )
         agg = pd.concat([agg, others[agg.columns]], ignore_index=True)
 
-    agg = agg.sort_values(["state", "birth_year", "first_name"])
+    agg = agg.sort_values(
+        ["state", "birth_year", "first_name"], kind="mergesort"
+    ).reset_index(drop=True)
     outp = Path(args.out)
-    outp.parent.mkdir(parents=True, exist_ok=True)
-    agg.to_csv(outp, index=False, compression="gzip")
+    write_deterministic_gzip_csv(agg, outp)
     LOGGER.info(
         "Wrote %s state-year-name rows and %s unique English names to %s",
         f"{len(agg):,}",

--- a/model_training/train_gender_lstm.py
+++ b/model_training/train_gender_lstm.py
@@ -16,6 +16,7 @@ import gzip
 import hashlib
 import json
 import logging
+import platform
 import random
 import re
 import tempfile
@@ -29,6 +30,7 @@ import torch.nn.functional as torch_functional
 
 from model_training.evaluation import (
     fit_logistic_calibration,
+    name_membership_sha256,
     probability_metrics,
     report_metrics,
     split_summary,
@@ -184,6 +186,7 @@ def main() -> None:
     best_validation_loss = float("inf")
     best_epoch = 0
     best_state: dict[str, torch.Tensor] | None = None
+    selection_history: list[dict[str, float | int]] = []
 
     for epoch in range(1, arguments.epochs + 1):
         model.train()
@@ -219,8 +222,19 @@ def main() -> None:
             proportions[split.validation],
             counts[split.validation],
         )
-        if validation_metrics.soft_log_loss < best_validation_loss:
-            best_validation_loss = validation_metrics.soft_log_loss
+        training_loss = running / len(sampled_indices)
+        validation_loss = validation_metrics.expected_binary_log_loss
+        selection_history.append(
+            {
+                "epoch": epoch,
+                "training_expected_binary_log_loss": training_loss,
+                "validation_person_weighted_expected_binary_log_loss": (
+                    validation_loss
+                ),
+            }
+        )
+        if validation_loss < best_validation_loss:
+            best_validation_loss = validation_loss
             best_epoch = epoch
             best_state = {
                 name: parameter.detach().cpu().clone()
@@ -230,10 +244,10 @@ def main() -> None:
             "Epoch %s: training loss %.4f; validation log loss %.4f; "
             "validation root Brier score %.4f; validation accuracy %.4f",
             epoch,
-            running / len(sampled_indices),
-            validation_metrics.soft_log_loss,
-            validation_metrics.root_brier_score,
-            validation_metrics.majority_label_accuracy,
+            training_loss,
+            validation_loss,
+            validation_metrics.expected_binary_root_brier_score,
+            validation_metrics.majority_name_label_accuracy,
         )
 
     if best_state is None:
@@ -262,7 +276,7 @@ def main() -> None:
     torch.save(best_state, checkpoint_path)
     metadata_path = arguments.metadata_out or checkpoint_path.with_suffix(".json")
     training_report = {
-        "schema_version": 1,
+        "schema_version": 2,
         "target": "female share among female and male electoral-roll labels",
         "reference_population": (
             "aggregated Indian electoral-roll registration records represented "
@@ -276,20 +290,81 @@ def main() -> None:
         "model": {
             "filename": checkpoint_path.name,
             "sha256": file_sha256(checkpoint_path),
-            "architecture": "character_bidirectional_lstm",
+            "architecture": {
+                "type": "character_bidirectional_lstm",
+                "vocabulary_size": VOCAB_SIZE,
+                "embedding_dimension": LSTM_EMB,
+                "hidden_dimension": LSTM_HIDDEN,
+                "layers": LSTM_LAYERS,
+                "dropout": LSTM_DROPOUT,
+            },
             "selected_epoch": best_epoch,
-            "selection_metric": "person_weighted_soft_log_loss",
+            "selection_metric": ("validation_person_weighted_expected_binary_log_loss"),
+            "selection_value": best_validation_loss,
+            "selection_history": selection_history,
+        },
+        "training": {
+            "random_seed": arguments.seed,
+            "hyperparameters": {
+                "epochs_requested": arguments.epochs,
+                "samples_per_epoch": arguments.samples_per_epoch,
+                "batch_size": arguments.batch_size,
+                "max_source_rows": arguments.max_rows,
+                "loss": "binary_cross_entropy_with_logits",
+                "training_name_sampling": "person_count_weighted_with_replacement",
+            },
+            "optimizer": {
+                "type": "torch.optim.Adam",
+                "learning_rate": arguments.learning_rate,
+                "betas": list(optimizer.defaults["betas"]),
+                "epsilon": optimizer.defaults["eps"],
+                "weight_decay": optimizer.defaults["weight_decay"],
+                "amsgrad": optimizer.defaults["amsgrad"],
+            },
+            "device": {
+                "requested": arguments.device,
+                "resolved": device,
+            },
+            "software_versions": {
+                "python": platform.python_version(),
+                "numpy": np.__version__,
+                "pandas": pd.__version__,
+                "torch": torch.__version__,
+            },
         },
         "split": {
             "method": "stratified disjoint unique-name split",
             "seed": arguments.seed,
+            "fractions": {
+                "training": 0.70,
+                "validation": 0.10,
+                "calibration": 0.10,
+                "test": 0.10,
+            },
+            "strata": {
+                "person_count_rank_bins": 100,
+                "female_proportion_bins": 10,
+            },
             "summary": split_summary(split, proportions, counts),
+            "membership_sha256": {
+                "training": name_membership_sha256(names, split.training),
+                "validation": name_membership_sha256(names, split.validation),
+                "calibration": name_membership_sha256(names, split.calibration),
+                "test": name_membership_sha256(names, split.test),
+            },
         },
         "calibration": {
             "method": "positive-scale logistic calibration",
             "scale": calibration.scale,
             "intercept": calibration.intercept,
             "fit_partition": "calibration",
+            "required_for_calibrated_serving": True,
+            "current_runtime_status": "not_applied",
+        },
+        "serving": {
+            "checkpoint_probabilities": "uncalibrated",
+            "calibrated_serving_requires": metadata_path.name,
+            "current_naampy_runtime_applies_manifest_calibration": False,
         },
         "test_metrics": {
             "raw": report_metrics(

--- a/model_training/train_gender_lstm.py
+++ b/model_training/train_gender_lstm.py
@@ -1,30 +1,40 @@
-"""Train the naampy gender char-BiLSTM (first name -> P(female)) on the v3 data.
+"""Train the Naampy character BiLSTM on the v3 data.
 
 Replaces the legacy TensorFlow char-CNN. Aggregates the (state,year,first_name) table to a
 global ``first_name -> female_prop`` target (weighted by count), trains a torch ``CharBiLSTM``
 with a single sigmoid output. CPU-trainable.
 
-    python train_gender_lstm.py --data model_training/data/naampy_v3.csv.gz \
+    uv run python -m model_training.train_gender_lstm \
+        --data model_training/data/naampy_v3.csv.gz \
         --out gender_lstm.pt --epochs 12
 """
 
+from __future__ import annotations
+
 import argparse
 import gzip
+import hashlib
+import json
+import logging
 import random
 import re
-import sys
+import tempfile
 from pathlib import Path
+from typing import Any, cast
 
 import numpy as np
 import pandas as pd
+import torch
+import torch.nn.functional as torch_functional
 
-NAAMPY_ROOT = Path(__file__).resolve().parents[1]
-# Import nnets.py directly (not the naampy package) to avoid the package __init__'s imports.
-sys.path.insert(0, str(NAAMPY_ROOT / "src" / "naampy"))
-
-import torch  # noqa: E402
-import torch.nn.functional as F  # noqa: E402
-from nnets import (  # noqa: E402
+from model_training.evaluation import (
+    fit_logistic_calibration,
+    probability_metrics,
+    report_metrics,
+    split_summary,
+    stratified_name_split,
+)
+from naampy.nnets import (
     LSTM_DROPOUT,
     LSTM_EMB,
     LSTM_HIDDEN,
@@ -36,107 +46,273 @@ from nnets import (  # noqa: E402
 )
 
 _REPEAT3 = re.compile(r"(.)\1\1")
+LOGGER = logging.getLogger(__name__)
 
 
-def load_names(path, max_rows=None):
+def load_names(
+    path: str | Path, max_rows: int | None = None
+) -> tuple[list[str], list[list[int]], list[float], list[float]]:
     """Aggregate to global first_name -> (female_prop, count); apply naampy's name filters."""
-    with gzip.open(path, "rt", encoding="utf-8") as fh:
-        df = pd.read_csv(fh, nrows=max_rows, dtype={"first_name": str})
-    g = df.groupby("first_name")[["n_female", "n_male"]].sum()
-    g = g[(g.n_female + g.n_male) > 0]
-    names, enc, prop, wt = [], [], [], []
-    for name, (nf, nm) in zip(g.index, g.to_numpy(), strict=True):
+    with gzip.open(path, "rt", encoding="utf-8") as compressed_file:
+        source_table = pd.read_csv(
+            compressed_file, nrows=max_rows, dtype={"first_name": str}
+        )
+    grouped_names = cast(
+        "pd.DataFrame",
+        source_table.groupby("first_name", as_index=False)[
+            ["n_female", "n_male"]
+        ].sum(),
+    )
+    grouped_names = grouped_names[
+        (grouped_names["n_female"] + grouped_names["n_male"]) > 0
+    ]
+    names: list[str] = []
+    encoded_names: list[list[int]] = []
+    female_proportions: list[float] = []
+    person_counts: list[float] = []
+    for name_value, female_value, male_value in grouped_names.itertuples(
+        index=False, name=None
+    ):
+        name = str(name_value)
+        female_count = float(female_value)
+        male_count = float(male_value)
         if not (2 < len(name) < 20) or not name.isalpha() or _REPEAT3.search(name):
             continue
-        e = encode_name(name)
-        if not e:
+        encoded_name = encode_name(name)
+        if not encoded_name:
             continue
         names.append(name)
-        enc.append(e)
-        prop.append(nf / (nf + nm))
-        wt.append(float(nf + nm))
-    return names, enc, prop, wt
+        encoded_names.append(encoded_name)
+        female_proportions.append(female_count / (female_count + male_count))
+        person_counts.append(female_count + male_count)
+    return names, encoded_names, female_proportions, person_counts
 
 
 @torch.no_grad()
-def evaluate(model, enc, prop, device):
-    """Held-out RMSE on P(female) + accuracy@0.5 (vs the >0.5 female label)."""
+def predict_probabilities(
+    model: CharBiLSTM,
+    encoded_names: list[list[int]],
+    device: str,
+) -> np.ndarray:
+    """Return female-name-pattern probabilities for encoded names."""
     model.eval()
-    se = correct = 0.0
-    for i in range(0, len(enc), 512):
-        x, lengths = pad_encoded(enc[i : i + 512])
-        p = torch.sigmoid(model(x.to(device), lengths)).squeeze(1).cpu().numpy()
-        t = np.array(prop[i : i + 512])
-        se += float(((p - t) ** 2).sum())
-        correct += float(((p > 0.5) == (t > 0.5)).sum())
-    return (se / len(enc)) ** 0.5, correct / len(enc)
+    probabilities: list[float] = []
+    for start in range(0, len(encoded_names), 512):
+        inputs, lengths = pad_encoded(encoded_names[start : start + 512])
+        batch_probabilities = (
+            torch.sigmoid(model(inputs.to(device), lengths)).squeeze(1).cpu().numpy()
+        )
+        probabilities.extend(batch_probabilities.tolist())
+    return np.asarray(probabilities)
+
+
+def file_sha256(path: Path) -> str:
+    """Return the SHA-256 digest of a file."""
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        while chunk := source.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def write_json_atomic(report: dict[str, Any], output_path: Path) -> None:
+    """Write a JSON document without exposing a partial file."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        dir=output_path.parent,
+        prefix=f".{output_path.name}.",
+        suffix=".tmp",
+        delete=False,
+    ) as temporary_file:
+        json.dump(report, temporary_file, indent=2, sort_keys=True)
+        temporary_file.write("\n")
+        temporary_path = Path(temporary_file.name)
+    temporary_path.replace(output_path)
+    output_path.chmod(0o644)
 
 
 def main() -> None:
-    ap = argparse.ArgumentParser()
-    ap.add_argument("--data", required=True)
-    ap.add_argument("--out", required=True)
-    ap.add_argument("--epochs", type=int, default=12)
-    ap.add_argument("--samples-per-epoch", type=int, default=300_000)
-    ap.add_argument("--batch-size", type=int, default=256)
-    ap.add_argument("--lr", type=float, default=1e-3)
-    ap.add_argument("--max-rows", type=int, default=None, help="cap (smoke test)")
-    ap.add_argument("--device", default="auto")
-    ap.add_argument("--seed", type=int, default=0)
-    args = ap.parse_args()
+    """Train and save a character BiLSTM checkpoint."""
+    argument_parser = argparse.ArgumentParser()
+    argument_parser.add_argument("--data", required=True)
+    argument_parser.add_argument("--out", required=True)
+    argument_parser.add_argument("--metadata-out", type=Path)
+    argument_parser.add_argument("--epochs", type=int, default=12)
+    argument_parser.add_argument("--samples-per-epoch", type=int, default=300_000)
+    argument_parser.add_argument("--batch-size", type=int, default=256)
+    argument_parser.add_argument("--learning-rate", type=float, default=1e-3)
+    argument_parser.add_argument(
+        "--max-rows", type=int, default=None, help="cap for a smoke test"
+    )
+    argument_parser.add_argument("--device", default="auto")
+    argument_parser.add_argument("--seed", type=int, default=0)
+    arguments = argument_parser.parse_args()
 
-    random.seed(args.seed)
-    torch.manual_seed(args.seed)
+    random.seed(arguments.seed)
+    torch.manual_seed(arguments.seed)
     device = (
         ("cuda" if torch.cuda.is_available() else "cpu")
-        if args.device == "auto"
-        else args.device
+        if arguments.device == "auto"
+        else arguments.device
     )
 
-    names, enc, prop, wt = load_names(args.data, args.max_rows)
-    idx = list(range(len(enc)))
-    random.shuffle(idx)
-    cut = int(0.8 * len(idx))
-    train_idx, test_idx = idx[:cut], idx[cut:]
-    train_w = [wt[i] for i in train_idx]
-    te = [enc[i] for i in test_idx]
-    tp = [prop[i] for i in test_idx]
-    print(
-        f"names {len(names):,} (train {len(train_idx):,}/test {len(test_idx):,}) | device {device}",
-        flush=True,
+    names, encoded_names, female_proportions, person_counts = load_names(
+        arguments.data, arguments.max_rows
+    )
+    proportions = np.asarray(female_proportions)
+    counts = np.asarray(person_counts)
+    split = stratified_name_split(proportions, counts, seed=arguments.seed)
+    training_weights = counts[split.training].tolist()
+    LOGGER.info(
+        "Names: %s; training: %s; validation: %s; calibration: %s; "
+        "test: %s; device: %s",
+        f"{len(names):,}",
+        f"{len(split.training):,}",
+        f"{len(split.validation):,}",
+        f"{len(split.calibration):,}",
+        f"{len(split.test):,}",
+        device,
     )
 
     model = CharBiLSTM(
         VOCAB_SIZE, 1, LSTM_EMB, LSTM_HIDDEN, LSTM_LAYERS, LSTM_DROPOUT
     ).to(device)
-    opt = torch.optim.Adam(model.parameters(), lr=args.lr)
-    bs = args.batch_size
+    optimizer = torch.optim.Adam(model.parameters(), lr=arguments.learning_rate)
+    batch_size = arguments.batch_size
+    best_validation_loss = float("inf")
+    best_epoch = 0
+    best_state: dict[str, torch.Tensor] | None = None
 
-    for epoch in range(1, args.epochs + 1):
+    for epoch in range(1, arguments.epochs + 1):
         model.train()
-        sample = random.choices(train_idx, weights=train_w, k=args.samples_per_epoch)
+        sampled_indices = random.choices(  # noqa: S311
+            split.training.tolist(),
+            weights=training_weights,
+            k=arguments.samples_per_epoch,
+        )
         running = 0.0
-        for i in range(0, len(sample), bs):
-            chunk = sample[i : i + bs]
-            x, lengths = pad_encoded([enc[j] for j in chunk])
-            target = torch.tensor([[prop[j]] for j in chunk], dtype=torch.float32)
-            logits = model(x.to(device), lengths)
-            loss = F.binary_cross_entropy_with_logits(logits, target.to(device))
-            opt.zero_grad()
+        for start in range(0, len(sampled_indices), batch_size):
+            batch_indices = sampled_indices[start : start + batch_size]
+            inputs, lengths = pad_encoded(
+                [encoded_names[index] for index in batch_indices]
+            )
+            target = torch.tensor(
+                [[proportions[index]] for index in batch_indices], dtype=torch.float32
+            )
+            logits = model(inputs.to(device), lengths)
+            loss = torch_functional.binary_cross_entropy_with_logits(
+                logits, target.to(device)
+            )
+            optimizer.zero_grad()
             loss.backward()
-            opt.step()
-            running += loss.item() * len(chunk)
-        rmse, acc = evaluate(model, te, tp, device)
-        print(
-            f"epoch {epoch:2d}  loss {running / len(sample):.4f}  "
-            f"rmse {rmse:.4f}  acc {acc:.4f}",
-            flush=True,
+            optimizer.step()
+            running += loss.item() * len(batch_indices)
+        validation_probabilities = predict_probabilities(
+            model,
+            [encoded_names[index] for index in split.validation],
+            device,
+        )
+        validation_metrics = probability_metrics(
+            validation_probabilities,
+            proportions[split.validation],
+            counts[split.validation],
+        )
+        if validation_metrics.soft_log_loss < best_validation_loss:
+            best_validation_loss = validation_metrics.soft_log_loss
+            best_epoch = epoch
+            best_state = {
+                name: parameter.detach().cpu().clone()
+                for name, parameter in model.state_dict().items()
+            }
+        LOGGER.info(
+            "Epoch %s: training loss %.4f; validation log loss %.4f; "
+            "validation root Brier score %.4f; validation accuracy %.4f",
+            epoch,
+            running / len(sampled_indices),
+            validation_metrics.soft_log_loss,
+            validation_metrics.root_brier_score,
+            validation_metrics.majority_label_accuracy,
         )
 
-    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
-    torch.save(model.state_dict(), args.out)
-    print(f"saved -> {args.out}", flush=True)
+    if best_state is None:
+        raise RuntimeError("Training did not produce a model checkpoint")
+    model.load_state_dict(best_state)
+
+    calibration_probabilities = predict_probabilities(
+        model,
+        [encoded_names[index] for index in split.calibration],
+        device,
+    )
+    calibration = fit_logistic_calibration(
+        calibration_probabilities,
+        proportions[split.calibration],
+        counts[split.calibration],
+    )
+    test_probabilities = predict_probabilities(
+        model,
+        [encoded_names[index] for index in split.test],
+        device,
+    )
+    calibrated_test_probabilities = calibration.apply(test_probabilities)
+
+    checkpoint_path = Path(arguments.out)
+    checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
+    torch.save(best_state, checkpoint_path)
+    metadata_path = arguments.metadata_out or checkpoint_path.with_suffix(".json")
+    training_report = {
+        "schema_version": 1,
+        "target": "female share among female and male electoral-roll labels",
+        "reference_population": (
+            "aggregated Indian electoral-roll registration records represented "
+            "in the Naampy v3 construction"
+        ),
+        "data": {
+            "filename": Path(arguments.data).name,
+            "sha256": file_sha256(Path(arguments.data)),
+            "usable_unique_names": len(names),
+        },
+        "model": {
+            "filename": checkpoint_path.name,
+            "sha256": file_sha256(checkpoint_path),
+            "architecture": "character_bidirectional_lstm",
+            "selected_epoch": best_epoch,
+            "selection_metric": "person_weighted_soft_log_loss",
+        },
+        "split": {
+            "method": "stratified disjoint unique-name split",
+            "seed": arguments.seed,
+            "summary": split_summary(split, proportions, counts),
+        },
+        "calibration": {
+            "method": "positive-scale logistic calibration",
+            "scale": calibration.scale,
+            "intercept": calibration.intercept,
+            "fit_partition": "calibration",
+        },
+        "test_metrics": {
+            "raw": report_metrics(
+                test_probabilities,
+                proportions[split.test],
+                counts[split.test],
+            ),
+            "calibrated": report_metrics(
+                calibrated_test_probabilities,
+                proportions[split.test],
+                counts[split.test],
+            ),
+        },
+    }
+    write_json_atomic(training_report, metadata_path)
+    LOGGER.info(
+        "Saved epoch %s checkpoint to %s and metadata to %s",
+        best_epoch,
+        checkpoint_path,
+        metadata_path,
+    )
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
     main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,14 @@ build-backend = "uv_build"
 [tool.uv.build-backend]
 module-name = "naampy"
 source-exclude = [".DS_Store", "Thumbs.db"]
+source-include = [
+    "model_training/DATA.md",
+    "model_training/__init__.py",
+    "model_training/evaluate_gender_model.py",
+    "model_training/evaluation.py",
+    "model_training/reports/*.json",
+    "model_training/train_gender_lstm.py",
+]
 
 [project]
 name = "naampy"
@@ -77,7 +85,6 @@ line-length = 88
 target-version = "py311"
 exclude = [
     "docs",
-    "model_training",
     "streamlit",
     "src/naampy/data",
     "*.ipynb",
@@ -160,5 +167,10 @@ allow-init-docstring = true
 exclude = '\.venv|tests|docs'
 
 [tool.pyright]
-include = ["src"]
+include = [
+    "src",
+    "model_training/evaluate_gender_model.py",
+    "model_training/evaluation.py",
+    "model_training/train_gender_lstm.py",
+]
 typeCheckingMode = "standard"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ source-include = [
     "model_training/evaluate_gender_model.py",
     "model_training/evaluation.py",
     "model_training/reports/*.json",
+    "model_training/retransliterate_native.py",
     "model_training/train_gender_lstm.py",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["uv_build>=0.11.32,<0.13"]
+requires = ["uv_build>=0.12.5,<0.13"]
 build-backend = "uv_build"
 
 [tool.uv.build-backend]
@@ -36,7 +36,7 @@ dependencies = [
   "pandas>=2.0.0",
   "requests>=2.25.0",
   "tqdm>=4.60.0",
-  "huggingface-hub>=0.23",
+  "huggingface-hub>=1.27.0",
   "pyarrow>=16",
 ]
 license-files = ["LICENSE"]

--- a/src/naampy/in_rolls_fn.py
+++ b/src/naampy/in_rolls_fn.py
@@ -5,6 +5,7 @@ import logging
 import sys
 import tempfile
 from pathlib import Path
+from typing import Any, cast
 
 import numpy as np
 import pandas as pd
@@ -35,8 +36,7 @@ IN_ROLLS_DATA = {
     "v2_en": "https://dataverse.harvard.edu/api/v1/access/datafile/6457224",
     # v3: native first names re-romanized via the eroll corpora + v2's non-native states
     # (31 states, full coverage). Build: model_training/retransliterate_native.py. After
-    # uploading naampy_v3.csv.gz to Dataverse, add its datafile URL here and default to it.
-    # "v3": "https://dataverse.harvard.edu/api/v1/access/datafile/<ID>",
+    # publishing naampy_v3.csv.gz, add its immutable URL here and default to it.
 }
 
 IN_ROLLS_COLS = [
@@ -79,7 +79,7 @@ class InRollsFnData:
     The class maintains cached data and models for efficient repeated predictions.
     """
 
-    __df = None
+    __df: pd.DataFrame | None = None
     __cache_key: tuple[str, str | None, int | None] | None = None
     __model = None
 
@@ -173,7 +173,13 @@ class InRollsFnData:
         )
 
         if len(first_names) == 0:
-            return pd.DataFrame(columns=["name", "pred_gender", "pred_prob"])
+            return pd.DataFrame(
+                {
+                    "name": pd.Series(dtype="object"),
+                    "pred_gender": pd.Series(dtype="object"),
+                    "pred_prob": pd.Series(dtype="float64"),
+                }
+            )
 
         # Load the pinned char-BiLSTM once (lazy; cached on the class).
         if cls.__model is None:
@@ -308,16 +314,19 @@ class InRollsFnData:
         cache_key = (dataset, state, year)
         if cls.__df is None or cls.__cache_key != cache_key:
             data_path = InRollsFnData.load_naampy_data(dataset)
-            adf = pd.read_parquet(
-                data_path,
-                columns=[
-                    "state",
-                    "birth_year",
-                    "first_name",
-                    "n_female",
-                    "n_male",
-                    "n_third_gender",
-                ],
+            adf = cast(
+                "pd.DataFrame",
+                pd.read_parquet(
+                    data_path,
+                    columns=[
+                        "state",
+                        "birth_year",
+                        "first_name",
+                        "n_female",
+                        "n_male",
+                        "n_third_gender",
+                    ],
+                ),
             )
             if state is not None and state not in set(adf["state"]):
                 choices = ", ".join(sorted(adf["state"].unique()))
@@ -337,24 +346,37 @@ class InRollsFnData:
                 adf = adf[adf.birth_year == year]
             # Always collapse to one row per name: guarantees a unique merge key
             # regardless of how many (state, birth_year) rows survived the filter.
-            adf = adf.groupby("first_name", as_index=False).agg(
-                {"n_female": "sum", "n_male": "sum", "n_third_gender": "sum"}
+            table_for_aggregation: Any = adf
+            adf = cast(
+                "pd.DataFrame",
+                table_for_aggregation.groupby("first_name", as_index=False).agg(
+                    {
+                        "n_female": "sum",
+                        "n_male": "sum",
+                        "n_third_gender": "sum",
+                    }
+                ),
             )
-            n = (adf["n_female"] + adf["n_male"] + adf["n_third_gender"]).replace(
-                0, np.nan
-            )
-            adf["prop_female"] = adf["n_female"] / n
-            adf["prop_male"] = adf["n_male"] / n
-            adf["prop_third_gender"] = adf["n_third_gender"] / n
-            adf = adf[["first_name", *IN_ROLLS_COLS]].rename(
-                columns={"first_name": "__first_name"}
+            total_count = cast(
+                "Any",
+                adf["n_female"] + adf["n_male"] + adf["n_third_gender"],
+            ).replace(0, np.nan)
+            adf["prop_female"] = adf["n_female"] / total_count
+            adf["prop_male"] = adf["n_male"] / total_count
+            adf["prop_third_gender"] = adf["n_third_gender"] / total_count
+            selected_columns: Any = adf[["first_name", *IN_ROLLS_COLS]]
+            adf = cast(
+                "pd.DataFrame",
+                selected_columns.rename(columns={"first_name": "__first_name"}),
             )
             adf["__first_name"] = adf["__first_name"].astype("string")
             cls.__df = adf
             cls.__cache_key = cache_key
-        lookup = cls.__df.set_index("__first_name")
+        lookup_frame = cast("pd.DataFrame", cls.__df)
+        lookup = lookup_frame.set_index("__first_name")
         for column in IN_ROLLS_COLS:
-            rdf[column] = rdf["__first_name"].map(lookup[column])
+            lookup_values: Any = lookup[column]
+            rdf[column] = rdf["__first_name"].map(lookup_values)
         for column in ("n_male", "n_female", "n_third_gender"):
             rdf[column] = rdf[column].astype("Int64")
 

--- a/tests/test_model_command_outputs.py
+++ b/tests/test_model_command_outputs.py
@@ -7,8 +7,10 @@ import pytest
 import torch
 
 from model_training.evaluate_gender_model import (
+    SHIPPED_CHECKPOINT_DATA_SHA256,
     file_sha256,
     load_verified_training_split,
+    verify_shipped_evaluation_artifacts,
 )
 from model_training.evaluation import name_membership_sha256, stratified_name_split
 from model_training.train_gender_lstm import load_names
@@ -55,6 +57,34 @@ def _write_smoke_data(path):
         }
     )
     table.to_csv(path, index=False, compression="gzip")
+
+
+def test_shipped_evaluation_rejects_unverified_data(tmp_path):
+    data_path = tmp_path / "data.csv.gz"
+    model_path = tmp_path / "gender_lstm.pt"
+    data_path.write_bytes(b"unverified data")
+    model_path.write_bytes(b"unverified checkpoint")
+
+    with pytest.raises(ValueError, match="--data does not match"):
+        verify_shipped_evaluation_artifacts(data_path, model_path)
+
+
+def test_shipped_evaluation_rejects_unverified_checkpoint(tmp_path, monkeypatch):
+    data_path = tmp_path / "data.csv.gz"
+    model_path = tmp_path / "gender_lstm.pt"
+    data_path.write_bytes(b"data hash is replaced below")
+    model_path.write_bytes(b"unverified checkpoint")
+    monkeypatch.setattr(
+        "model_training.evaluate_gender_model.file_sha256",
+        lambda path: (
+            SHIPPED_CHECKPOINT_DATA_SHA256
+            if path == data_path
+            else "unverified-checkpoint"
+        ),
+    )
+
+    with pytest.raises(ValueError, match="does not match the checkpoint"):
+        verify_shipped_evaluation_artifacts(data_path, model_path)
 
 
 def test_custom_checkpoint_evaluation_reports_local_provenance(tmp_path):

--- a/tests/test_model_command_outputs.py
+++ b/tests/test_model_command_outputs.py
@@ -101,6 +101,8 @@ def test_custom_checkpoint_evaluation_reports_local_provenance(tmp_path):
     )
     manifest = {
         "schema_version": 2,
+        "target": "female share in a custom labeled source",
+        "reference_population": "custom research records",
         "data": {"sha256": file_sha256(data_path)},
         "model": {"sha256": file_sha256(model_path)},
         "training": {"hyperparameters": {"max_source_rows": None}},
@@ -157,6 +159,8 @@ def test_custom_checkpoint_evaluation_reports_local_provenance(tmp_path):
     assert report["model"]["provenance"]["training_manifest"]["sha256"] == (
         file_sha256(manifest_path)
     )
+    assert report["target"] == "female share in a custom labeled source"
+    assert report["reference_population"] == "custom research records"
     assert report["split"]["seed"] == 37
     assert report["metrics"]["balanced_test_raw"]["intervals"]["seed"] == 91
 
@@ -268,6 +272,8 @@ def test_custom_manifest_rejects_inconsistent_test_fraction(tmp_path):
     )
     manifest = {
         "schema_version": 2,
+        "target": "female share in a custom labeled source",
+        "reference_population": "custom research records",
         "data": {"sha256": file_sha256(data_path)},
         "model": {"sha256": file_sha256(model_path)},
         "training": {"hyperparameters": {"max_source_rows": None}},

--- a/tests/test_model_command_outputs.py
+++ b/tests/test_model_command_outputs.py
@@ -1,0 +1,278 @@
+import json
+import subprocess
+import sys
+
+import pandas as pd
+import pytest
+import torch
+
+from model_training.evaluate_gender_model import (
+    file_sha256,
+    load_verified_training_split,
+)
+from model_training.evaluation import name_membership_sha256, stratified_name_split
+from model_training.train_gender_lstm import load_names
+from naampy.nnets import (
+    LSTM_DROPOUT,
+    LSTM_EMB,
+    LSTM_HIDDEN,
+    LSTM_LAYERS,
+    VOCAB_SIZE,
+    CharBiLSTM,
+)
+
+
+def _write_smoke_data(path):
+    names = [
+        "aarav",
+        "aditi",
+        "akash",
+        "ananya",
+        "arjun",
+        "diya",
+        "esha",
+        "isha",
+        "kabir",
+        "kavya",
+        "kiara",
+        "meera",
+        "neha",
+        "priya",
+        "rahul",
+        "rohan",
+        "saanvi",
+        "tara",
+        "varun",
+        "vivaan",
+    ]
+    table = pd.DataFrame(
+        {
+            "state": "smoke",
+            "birth_year": 1990,
+            "first_name": names,
+            "n_female": [(index * 3) % 11 + 1 for index in range(len(names))],
+            "n_male": [(index * 5) % 13 + 1 for index in range(len(names))],
+        }
+    )
+    table.to_csv(path, index=False, compression="gzip")
+
+
+def test_custom_checkpoint_evaluation_reports_local_provenance(tmp_path):
+    data_path = tmp_path / "smoke.csv.gz"
+    model_path = tmp_path / "custom.pt"
+    manifest_path = tmp_path / "custom.json"
+    report_path = tmp_path / "evaluation.json"
+    _write_smoke_data(data_path)
+    model = CharBiLSTM(VOCAB_SIZE, 1, LSTM_EMB, LSTM_HIDDEN, LSTM_LAYERS, LSTM_DROPOUT)
+    torch.save(model.state_dict(), model_path)
+    names, _, female_proportions, person_counts = load_names(data_path)
+    split = stratified_name_split(
+        female_proportions, person_counts, seed=37, count_strata=5
+    )
+    manifest = {
+        "schema_version": 2,
+        "data": {"sha256": file_sha256(data_path)},
+        "model": {"sha256": file_sha256(model_path)},
+        "training": {"hyperparameters": {"max_source_rows": None}},
+        "split": {
+            "method": "stratified disjoint unique-name split",
+            "seed": 37,
+            "fractions": {
+                "training": 0.70,
+                "validation": 0.10,
+                "calibration": 0.10,
+                "test": 0.10,
+            },
+            "strata": {
+                "person_count_rank_bins": 5,
+                "female_proportion_bins": 10,
+            },
+            "membership_sha256": {
+                "training": name_membership_sha256(names, split.training),
+                "validation": name_membership_sha256(names, split.validation),
+                "calibration": name_membership_sha256(names, split.calibration),
+                "test": name_membership_sha256(names, split.test),
+            },
+        },
+    }
+    manifest_path.write_text(json.dumps(manifest))
+
+    completed_process = subprocess.run(  # noqa: S603
+        [
+            sys.executable,
+            "-m",
+            "model_training.evaluate_gender_model",
+            "--data",
+            str(data_path),
+            "--model",
+            str(model_path),
+            "--training-manifest",
+            str(manifest_path),
+            "--output",
+            str(report_path),
+            "--bootstrap-iterations",
+            "5",
+            "--bootstrap-seed",
+            "91",
+        ],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert completed_process.returncode == 0, completed_process.stderr
+    report = json.loads(report_path.read_text())
+    assert report["model"]["provenance"]["path"] == str(model_path)
+    assert report["model"]["provenance"]["source"] == "user_provided_local_path"
+    assert report["model"]["provenance"]["training_manifest"]["sha256"] == (
+        file_sha256(manifest_path)
+    )
+    assert report["split"]["seed"] == 37
+    assert report["metrics"]["balanced_test_raw"]["intervals"]["seed"] == 91
+
+
+def test_training_manifest_records_reproducibility_contract(tmp_path):
+    data_path = tmp_path / "smoke.csv.gz"
+    model_path = tmp_path / "trained.pt"
+    manifest_path = tmp_path / "trained.json"
+    _write_smoke_data(data_path)
+
+    completed_process = subprocess.run(  # noqa: S603
+        [
+            sys.executable,
+            "-m",
+            "model_training.train_gender_lstm",
+            "--data",
+            str(data_path),
+            "--out",
+            str(model_path),
+            "--metadata-out",
+            str(manifest_path),
+            "--epochs",
+            "2",
+            "--samples-per-epoch",
+            "8",
+            "--batch-size",
+            "4",
+            "--device",
+            "cpu",
+            "--max-rows",
+            "10",
+        ],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert completed_process.returncode == 0, completed_process.stderr
+    manifest = json.loads(manifest_path.read_text())
+    assert manifest["model"]["selection_value"] >= 0
+    assert len(manifest["model"]["selection_history"]) == 2
+    assert manifest["training"]["hyperparameters"] == {
+        "batch_size": 4,
+        "epochs_requested": 2,
+        "loss": "binary_cross_entropy_with_logits",
+        "max_source_rows": 10,
+        "samples_per_epoch": 8,
+        "training_name_sampling": "person_count_weighted_with_replacement",
+    }
+    assert manifest["training"]["optimizer"]["type"] == "torch.optim.Adam"
+    assert manifest["training"]["device"] == {
+        "requested": "cpu",
+        "resolved": "cpu",
+    }
+    assert set(manifest["training"]["software_versions"]) == {
+        "numpy",
+        "pandas",
+        "python",
+        "torch",
+    }
+    assert set(manifest["split"]["membership_sha256"]) == {
+        "training",
+        "validation",
+        "calibration",
+        "test",
+    }
+    assert manifest["serving"] == {
+        "calibrated_serving_requires": manifest_path.name,
+        "checkpoint_probabilities": "uncalibrated",
+        "current_naampy_runtime_applies_manifest_calibration": False,
+    }
+
+    evaluation_path = tmp_path / "trained-evaluation.json"
+    evaluation_process = subprocess.run(  # noqa: S603
+        [
+            sys.executable,
+            "-m",
+            "model_training.evaluate_gender_model",
+            "--data",
+            str(data_path),
+            "--model",
+            str(model_path),
+            "--training-manifest",
+            str(manifest_path),
+            "--output",
+            str(evaluation_path),
+            "--bootstrap-iterations",
+            "2",
+        ],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    assert evaluation_process.returncode == 0, evaluation_process.stderr
+    evaluation = json.loads(evaluation_path.read_text())
+    assert evaluation["data"]["source_row_limit"] == 10
+
+
+def test_custom_manifest_rejects_inconsistent_test_fraction(tmp_path):
+    data_path = tmp_path / "smoke.csv.gz"
+    model_path = tmp_path / "custom.pt"
+    manifest_path = tmp_path / "custom.json"
+    _write_smoke_data(data_path)
+    model = CharBiLSTM(VOCAB_SIZE, 1, LSTM_EMB, LSTM_HIDDEN, LSTM_LAYERS, LSTM_DROPOUT)
+    torch.save(model.state_dict(), model_path)
+    names, _, female_proportions, person_counts = load_names(data_path)
+    split = stratified_name_split(
+        female_proportions, person_counts, seed=37, count_strata=5
+    )
+    manifest = {
+        "schema_version": 2,
+        "data": {"sha256": file_sha256(data_path)},
+        "model": {"sha256": file_sha256(model_path)},
+        "training": {"hyperparameters": {"max_source_rows": None}},
+        "split": {
+            "method": "stratified disjoint unique-name split",
+            "seed": 37,
+            "fractions": {
+                "training": 0.70,
+                "validation": 0.10,
+                "calibration": 0.10,
+                "test": 0.20,
+            },
+            "strata": {
+                "person_count_rank_bins": 5,
+                "female_proportion_bins": 10,
+            },
+            "membership_sha256": {
+                partition: name_membership_sha256(names, indices)
+                for partition, indices in (
+                    ("training", split.training),
+                    ("validation", split.validation),
+                    ("calibration", split.calibration),
+                    ("test", split.test),
+                )
+            },
+        },
+    }
+    manifest_path.write_text(json.dumps(manifest))
+
+    with pytest.raises(ValueError, match="split fractions must sum to 1"):
+        load_verified_training_split(
+            manifest_path,
+            data_path,
+            model_path,
+            names,
+            female_proportions,
+            person_counts,
+        )

--- a/tests/test_model_evaluation.py
+++ b/tests/test_model_evaluation.py
@@ -68,6 +68,20 @@ def test_balanced_calibration_test_split_preserves_held_out_names():
     assert abs(counts[calibration].sum() - counts[test].sum()) <= counts.max()
 
 
+@pytest.mark.parametrize("proportion", [0.0, 1.0])
+def test_balanced_calibration_test_split_supports_single_class_targets(proportion):
+    proportions = np.full(8, proportion)
+    counts = np.arange(1, 9)
+    held_out = np.arange(8)
+
+    calibration, test = balanced_calibration_test_split(held_out, proportions, counts)
+
+    assert len(calibration) > 0
+    assert len(test) > 0
+    assert set(calibration).isdisjoint(test)
+    assert set(np.concatenate((calibration, test))) == set(held_out)
+
+
 def test_stratified_split_is_deterministic_disjoint_and_exhaustive():
     proportions = np.linspace(0, 1, 1_000)
     counts = np.arange(1, 1_001)

--- a/tests/test_model_evaluation.py
+++ b/tests/test_model_evaluation.py
@@ -1,0 +1,172 @@
+import subprocess
+import sys
+
+import numpy as np
+import pytest
+
+from model_training.evaluation import (
+    LogisticCalibration,
+    balanced_calibration_test_split,
+    bootstrap_metric_intervals,
+    expected_calibration_error,
+    fit_logistic_calibration,
+    legacy_development_split,
+    probability_metrics,
+    split_summary,
+    stratified_name_split,
+)
+
+
+def test_legacy_development_split_matches_original_recipe():
+    training, held_out = legacy_development_split(10, seed=0)
+
+    assert training.tolist() == [7, 8, 1, 5, 3, 4, 2, 0]
+    assert held_out.tolist() == [9, 6]
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        "model_training.evaluate_gender_model",
+        "model_training.train_gender_lstm",
+    ],
+)
+def test_model_command_help_runs(module_name):
+    completed_process = subprocess.run(  # noqa: S603
+        [sys.executable, "-m", module_name, "--help"],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert completed_process.returncode == 0, completed_process.stderr
+    assert "usage:" in completed_process.stdout
+
+
+def test_balanced_calibration_test_split_preserves_held_out_names():
+    proportions = np.linspace(0, 1, 100)
+    counts = np.arange(1, 101)
+    held_out = np.arange(20, 100)
+
+    calibration, test = balanced_calibration_test_split(held_out, proportions, counts)
+
+    assert set(calibration).isdisjoint(test)
+    assert set(np.concatenate((calibration, test))) == set(held_out)
+    assert abs(counts[calibration].sum() - counts[test].sum()) <= counts.max()
+
+
+def test_stratified_split_is_deterministic_disjoint_and_exhaustive():
+    proportions = np.linspace(0, 1, 1_000)
+    counts = np.arange(1, 1_001)
+
+    first = stratified_name_split(proportions, counts, seed=17)
+    second = stratified_name_split(proportions, counts, seed=17)
+
+    assert np.array_equal(first.training, second.training)
+    assert np.array_equal(first.validation, second.validation)
+    assert np.array_equal(first.calibration, second.calibration)
+    assert np.array_equal(first.test, second.test)
+    first.validate(len(proportions))
+    assert set(first.training).isdisjoint(first.validation)
+    assert set(first.training).isdisjoint(first.calibration)
+    assert set(first.training).isdisjoint(first.test)
+    assert set(first.validation).isdisjoint(first.calibration)
+    assert set(first.validation).isdisjoint(first.test)
+    assert set(first.calibration).isdisjoint(first.test)
+
+
+def test_stratified_split_preserves_support_and_target_composition():
+    proportions = np.tile(np.linspace(0, 1, 100), 20)
+    counts = np.tile(np.arange(1, 101), 20)
+    split = stratified_name_split(proportions, counts, seed=5)
+
+    summary = split_summary(split, proportions, counts)
+
+    person_totals = np.array([values["people"] for values in summary.values()])
+    person_shares = person_totals / person_totals.sum()
+    assert person_shares == pytest.approx([0.70, 0.10, 0.10, 0.10], abs=0.02)
+    female_shares = [values["female_share"] for values in summary.values()]
+    assert max(female_shares) - min(female_shares) < 0.02
+
+
+def test_probability_metrics_match_hand_calculation():
+    probabilities = np.array([0.9, 0.8, 0.4, 0.1])
+    proportions = np.array([1.0, 0.25, 0.75, 0.0])
+    weights = np.ones(4)
+
+    metrics = probability_metrics(probabilities, proportions, weights)
+
+    assert metrics.majority_label_accuracy == pytest.approx(0.5)
+    assert metrics.expected_person_accuracy == pytest.approx(0.625)
+    assert metrics.female_precision == pytest.approx(0.5)
+    assert metrics.female_recall == pytest.approx(0.5)
+    assert metrics.male_recall == pytest.approx(0.5)
+    assert metrics.female_f1 == pytest.approx(0.5)
+    assert metrics.brier_score == pytest.approx(
+        np.mean(np.square(probabilities - proportions))
+    )
+
+
+def test_expected_calibration_error_is_zero_for_matching_bin_means():
+    probabilities = np.array([0.1, 0.2, 0.8, 0.9])
+    proportions = np.array([0.0, 0.3, 0.7, 1.0])
+
+    error = expected_calibration_error(
+        probabilities, proportions, np.ones(4), number_of_bins=2
+    )
+
+    assert error == pytest.approx(0.0)
+
+
+def test_logistic_calibration_improves_overconfident_probabilities():
+    probabilities = np.array([0.001, 0.01, 0.99, 0.999])
+    proportions = np.array([0.2, 0.3, 0.7, 0.8])
+    weights = np.ones(4)
+
+    calibration = fit_logistic_calibration(probabilities, proportions, weights)
+    calibrated = calibration.apply(probabilities)
+
+    assert calibration.scale < 1
+    assert (
+        probability_metrics(calibrated, proportions, weights).soft_log_loss
+        < probability_metrics(probabilities, proportions, weights).soft_log_loss
+    )
+
+
+def test_identity_calibration_preserves_probabilities():
+    probabilities = np.array([0.2, 0.5, 0.8])
+
+    calibrated = LogisticCalibration(scale=1, intercept=0).apply(probabilities)
+
+    assert calibrated == pytest.approx(probabilities)
+
+
+def test_bootstrap_intervals_are_reproducible_and_contain_estimate():
+    probabilities = np.array([0.1, 0.3, 0.7, 0.9])
+    proportions = np.array([0.0, 0.2, 0.8, 1.0])
+    weights = np.ones(4)
+
+    first = bootstrap_metric_intervals(
+        probabilities, proportions, weights, iterations=50, seed=11
+    )
+    second = bootstrap_metric_intervals(
+        probabilities, proportions, weights, iterations=50, seed=11
+    )
+
+    assert first == second
+    for interval in first.values():
+        assert interval["lower"] <= interval["estimate"] <= interval["upper"]
+
+
+@pytest.mark.parametrize(
+    ("probabilities", "proportions", "weights"),
+    [
+        (np.array([]), np.array([]), np.array([])),
+        (np.array([1.1]), np.array([1.0]), np.array([1.0])),
+        (np.array([0.5]), np.array([np.nan]), np.array([1.0])),
+        (np.array([0.5]), np.array([0.5]), np.array([-1.0])),
+    ],
+)
+def test_probability_metrics_reject_invalid_inputs(probabilities, proportions, weights):
+    with pytest.raises(ValueError):
+        probability_metrics(probabilities, proportions, weights)

--- a/tests/test_model_evaluation.py
+++ b/tests/test_model_evaluation.py
@@ -43,6 +43,19 @@ def test_model_command_help_runs(module_name):
     assert "usage:" in completed_process.stdout
 
 
+def test_shipped_checkpoint_split_seed_is_not_configurable():
+    completed_process = subprocess.run(
+        [sys.executable, "-m", "model_training.evaluate_gender_model", "--help"],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert completed_process.returncode == 0, completed_process.stderr
+    assert "--bootstrap-seed" in completed_process.stdout
+    assert "--seed " not in completed_process.stdout
+
+
 def test_balanced_calibration_test_split_preserves_held_out_names():
     proportions = np.linspace(0, 1, 100)
     counts = np.arange(1, 101)
@@ -89,6 +102,107 @@ def test_stratified_split_preserves_support_and_target_composition():
     assert max(female_shares) - min(female_shares) < 0.02
 
 
+@pytest.mark.parametrize("number_of_names", [4, 5, 10])
+def test_stratified_split_keeps_small_partitions_nonempty(number_of_names):
+    proportions = np.linspace(0, 1, number_of_names)
+    counts = np.arange(1, number_of_names + 1)
+
+    split = stratified_name_split(proportions, counts, seed=5)
+
+    split.validate(number_of_names)
+    assert all(
+        len(partition) > 0
+        for partition in (
+            split.training,
+            split.validation,
+            split.calibration,
+            split.test,
+        )
+    )
+
+
+def test_nonempty_quota_adjustment_balances_against_realized_sizes():
+    proportions = np.full(5, 0.5)
+    counts = np.arange(1, 6)
+
+    split = stratified_name_split(proportions, counts, seed=5)
+    support_shares = (
+        np.array(
+            [
+                counts[partition].sum()
+                for partition in (
+                    split.training,
+                    split.validation,
+                    split.calibration,
+                    split.test,
+                )
+            ]
+        )
+        / counts.sum()
+    )
+
+    assert support_shares[0] == pytest.approx(0.40, abs=0.07)
+
+
+@pytest.mark.parametrize("number_of_names", [20, 100, 500])
+def test_stratified_split_respects_global_partition_sizes(number_of_names):
+    proportions = np.linspace(0, 1, number_of_names)
+    counts = np.arange(1, number_of_names + 1)
+
+    split = stratified_name_split(proportions, counts, seed=5)
+
+    assert [
+        len(split.training),
+        len(split.validation),
+        len(split.calibration),
+        len(split.test),
+    ] == pytest.approx(
+        np.array([0.70, 0.10, 0.10, 0.10]) * number_of_names,
+        abs=1,
+    )
+
+
+def test_sparse_strata_do_not_systematically_shift_support():
+    proportions = np.linspace(0, 1, 20)
+    counts = np.arange(1, 21)
+
+    split = stratified_name_split(proportions, counts, seed=5)
+    support_shares = (
+        np.array(
+            [
+                counts[partition].sum()
+                for partition in (
+                    split.training,
+                    split.validation,
+                    split.calibration,
+                    split.test,
+                )
+            ]
+        )
+        / counts.sum()
+    )
+
+    assert support_shares == pytest.approx([0.70, 0.10, 0.10, 0.10], abs=0.02)
+    female_compositions = np.array(
+        [
+            np.average(proportions[partition], weights=counts[partition])
+            for partition in (
+                split.training,
+                split.validation,
+                split.calibration,
+                split.test,
+            )
+        ]
+    )
+    overall_composition = np.average(proportions, weights=counts)
+    assert female_compositions == pytest.approx(overall_composition, abs=0.025)
+
+
+def test_stratified_split_requires_one_name_per_partition():
+    with pytest.raises(ValueError, match="At least four usable unique names"):
+        stratified_name_split(np.array([0.0, 0.5, 1.0]), np.ones(3))
+
+
 def test_probability_metrics_match_hand_calculation():
     probabilities = np.array([0.9, 0.8, 0.4, 0.1])
     proportions = np.array([1.0, 0.25, 0.75, 0.0])
@@ -96,14 +210,21 @@ def test_probability_metrics_match_hand_calculation():
 
     metrics = probability_metrics(probabilities, proportions, weights)
 
-    assert metrics.majority_label_accuracy == pytest.approx(0.5)
+    assert metrics.majority_name_label_accuracy == pytest.approx(0.5)
     assert metrics.expected_person_accuracy == pytest.approx(0.625)
-    assert metrics.female_precision == pytest.approx(0.5)
-    assert metrics.female_recall == pytest.approx(0.5)
-    assert metrics.male_recall == pytest.approx(0.5)
-    assert metrics.female_f1 == pytest.approx(0.5)
-    assert metrics.brier_score == pytest.approx(
+    assert metrics.expected_female_precision == pytest.approx(0.625)
+    assert metrics.expected_female_recall == pytest.approx(0.625)
+    assert metrics.expected_male_recall == pytest.approx(0.625)
+    assert metrics.expected_female_f1 == pytest.approx(0.625)
+    assert metrics.aggregate_composition_mean_squared_error == pytest.approx(
         np.mean(np.square(probabilities - proportions))
+    )
+    expected_binary_brier = np.mean(
+        np.square(probabilities - proportions) + proportions * (1 - proportions)
+    )
+    assert metrics.expected_binary_brier_score == pytest.approx(expected_binary_brier)
+    assert metrics.expected_binary_brier_score > (
+        metrics.aggregate_composition_mean_squared_error
     )
 
 
@@ -128,8 +249,10 @@ def test_logistic_calibration_improves_overconfident_probabilities():
 
     assert calibration.scale < 1
     assert (
-        probability_metrics(calibrated, proportions, weights).soft_log_loss
-        < probability_metrics(probabilities, proportions, weights).soft_log_loss
+        probability_metrics(calibrated, proportions, weights).expected_binary_log_loss
+        < probability_metrics(
+            probabilities, proportions, weights
+        ).expected_binary_log_loss
     )
 
 

--- a/tests/test_retransliterate_native.py
+++ b/tests/test_retransliterate_native.py
@@ -1,0 +1,30 @@
+import gzip
+
+import pandas as pd
+
+from model_training.retransliterate_native import write_deterministic_gzip_csv
+
+
+def test_deterministic_gzip_csv_is_path_and_time_independent(tmp_path):
+    table = pd.DataFrame(
+        {
+            "state": ["assam", "punjab"],
+            "birth_year": [1980.0, 1990.0],
+            "first_name": ["anita", "gurpreet"],
+            "n_female": [3, 2],
+            "n_male": [1, 4],
+            "n_third_gender": [0, 0],
+            "prop_female": [0.75, 1 / 3],
+        }
+    )
+    first_path = tmp_path / "first.csv.gz"
+    second_path = tmp_path / "second.csv.gz"
+
+    write_deterministic_gzip_csv(table, first_path)
+    write_deterministic_gzip_csv(table, second_path)
+
+    assert first_path.read_bytes() == second_path.read_bytes()
+    with gzip.open(first_path, "rt", encoding="utf-8", newline="") as source:
+        assert source.read().splitlines()[0] == (
+            "state,birth_year,first_name,n_female,n_male,n_third_gender,prop_female"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -719,7 +719,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "huggingface-hub", specifier = ">=0.23" },
+    { name = "huggingface-hub", specifier = ">=1.27.0" },
     { name = "numpy", specifier = ">=1.21.0" },
     { name = "pandas", specifier = ">=2.0.0" },
     { name = "pyarrow", specifier = ">=16" },


### PR DESCRIPTION
## What changed

- establishes a leakage-safe name-level evaluation contract with separate training, validation, calibration, and final-test partitions for future checkpoints
- audits the shipped character BiLSTM with name- and person-weighted probability metrics, name-cluster bootstrap intervals, immutable artifact hashes, and explicit developmental-evidence limitations
- corrects fractional-target precision, recall, F1, and Brier semantics for aggregated electoral-roll labels
- requires verified data, checkpoint, split-membership, target, and reference-population provenance for custom evaluations
- makes the v3 construction byte-deterministic and includes the maintained construction and evaluation tools in source distributions
- adopts the current py-canon template release and current uv-build/Hugging Face Hub APIs

This branch contains and supersedes the small toolchain-only change in #40.

## Product impact

This is a truthful evaluation and retraining foundation, not a claim that the current runtime model became more accurate. The shipped checkpoint's audit remains developmental because its original held-out partition was inspected during training. The current runtime still serves raw, uncalibrated probabilities; the offline calibration improves probability quality but is not silently applied to serving.

The next model comparison can now train challengers on the frozen 70/10/10/10 contract, select on validation data, calibrate on the calibration partition, and inspect the final test only after freezing the model.

## Validation

- `make test`: 78 passed, 27 intentionally network-gated skips, 1 deselected live test
- `make lint`: Ruff clean, Pyright 0 errors, pydoclint clean
- `make docs`: Sphinx warnings-as-errors build passed
- `uv build`: wheel and source distribution built; maintained model tools and report are present in the sdist
- strict shared Preen check: all checks passed
- independent full-diff review, corrections, and clean focused re-review
